### PR TITLE
[F0] Implementa SimulationClock (#5)

### DIFF
--- a/Sources/Stockflow.Simulation/Core/SimulationClock.cs
+++ b/Sources/Stockflow.Simulation/Core/SimulationClock.cs
@@ -1,0 +1,18 @@
+namespace Stockflow.Simulation.Core;
+
+public class SimulationClock
+{
+    private float _simulatedTime;
+
+    public float SimulatedTime => _simulatedTime;
+
+    public float TimeScale { get; set; } = 1f;
+
+    // Phase 2: enforced at 1x when external connections are active
+    public bool IsLiveMode => TimeScale == 1f;
+
+    public void Advance(float realDelta)
+    {
+        _simulatedTime += realDelta * TimeScale;
+    }
+}

--- a/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
+++ b/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
@@ -5,24 +5,25 @@ namespace Stockflow.Simulation.Core;
 
 public class SimulationEngine
 {
-    private float        _simulationTime;
     private HashSet<int> _knownComponentIds = new();
 
     public SimulationEngine(int width, int length, int height)
     {
+        Clock = new SimulationClock();
         Grid  = new GridManager(width, length, height);
         State = new();
     }
 
-    public float           TimeScale      { get; set; } = 1f;
-    public float           SimulationTime => _simulationTime;
+    public SimulationClock Clock          { get; }
+    public float           TimeScale      { get => Clock.TimeScale; set => Clock.TimeScale = value; }
+    public float           SimulationTime => Clock.SimulatedTime;
     public GridManager     Grid           { get; }
     public SimulationState State          { get; }
 
     // deltaTime è calcolato dal caller: 1f / tickRate * engine.TimeScale
     public void Tick(float deltaTime)
     {
-        _simulationTime += deltaTime;
+        Clock.Advance(deltaTime);
         foreach (var component in State.Components)
             component.Tick(deltaTime);
     }
@@ -45,7 +46,7 @@ public class SimulationEngine
 
         return new StateDelta
         {
-            SimulationTime      = _simulationTime,
+            SimulationTime      = Clock.SimulatedTime,
             AddedComponentIds   = added,
             RemovedComponentIds = removed,
         };


### PR DESCRIPTION
Estrae la logica temporale da SimulationEngine in una classe dedicata SimulationClock con SimulatedTime, TimeScale, IsLiveMode e Advance(). SimulationEngine espone Clock come proprietà pubblica e mantiene i proxy TimeScale/SimulationTime per retrocompatibilità con il webserver.