### PR TITLE
refactor: semplifica Entity system dopo review

### DIFF
--- a/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
+++ b/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
@@ -44,12 +44,19 @@ public class SimulationEngine
         var removedComponents = _knownComponentIds.Except(currentComponents).ToList();
         _knownComponentIds = currentComponents;
 
-        var currentEntities = State.Entities.GetAll().ToDictionary(e => e.Id);
-        var addedEntities   = currentEntities.Keys.Except(_knownEntityIds)
-                                             .Select(id => EntityState.From(currentEntities[id]))
-                                             .ToList();
-        var removedEntities = _knownEntityIds.Except(currentEntities.Keys).ToList();
-        _knownEntityIds = currentEntities.Keys.ToHashSet();
+        var currentEntities = State.Entities.Active;
+        var addedEntities   = new List<EntityState>();
+        foreach (var (id, entity) in currentEntities)
+            if (_knownEntityIds.Add(id))
+                addedEntities.Add(EntityState.From(entity));
+
+        var removedEntities = new List<int>();
+        _knownEntityIds.RemoveWhere(id =>
+        {
+            if (currentEntities.ContainsKey(id)) return false;
+            removedEntities.Add(id);
+            return true;
+        });
 
         return new StateDelta
         {

--- a/Sources/Stockflow.Simulation/Entity/Entity.cs
+++ b/Sources/Stockflow.Simulation/Entity/Entity.cs
@@ -10,29 +10,20 @@ public class SimEntity
     public float   Size      { get; internal set; }
     public float   EntryTime { get; internal set; }
 
-    // Posizione corrente
     public ISimComponent  CurrentComponent     { get; set; } = null!;
     public PortId         CurrentPort          { get; set; }
     public float          Progress             { get; set; }   // 0.0 ingresso → 1.0 uscita
 
-    // Destinazione
     public ISimComponent? DestinationComponent { get; set; }
 
-    // Stato macchina
     public EntityStatus Status { get; set; }
 
-    // Resetta tutti i campi per il riuso dal pool
+    // Rilascia i riferimenti per non trattenere oggetti vivi mentre l'entità è nel pool.
+    // I campi value-type vengono riscritti integralmente da Spawn al prossimo riuso.
     internal void Reset()
     {
-        Id                   = 0;
         Sku                  = "";
-        Weight               = 0f;
-        Size                 = 0f;
-        EntryTime            = 0f;
         CurrentComponent     = null!;
-        CurrentPort          = default;
-        Progress             = 0f;
         DestinationComponent = null;
-        Status               = EntityStatus.Idle;
     }
 }

--- a/Sources/Stockflow.Simulation/Entity/EntityManager.cs
+++ b/Sources/Stockflow.Simulation/Entity/EntityManager.cs
@@ -8,6 +8,8 @@ public class EntityManager
     private readonly Queue<SimEntity>           _pool   = new();
     private          int                        _nextId = 1;
 
+    public IReadOnlyDictionary<int, SimEntity> Active => _active;
+
     public IReadOnlyCollection<SimEntity> GetAll() => _active.Values;
 
     public IEnumerable<SimEntity> GetByComponent(int componentId)

--- a/Sources/Stockflow.Simulation/Entity/ISimEntity.cs
+++ b/Sources/Stockflow.Simulation/Entity/ISimEntity.cs
@@ -1,1 +1,0 @@
-// Rimosso in #6 — sostituito dalla classe concreta Entity.cs


### PR DESCRIPTION
- Rimuove Entity/ISimEntity.cs (file morto, sostituito da SimEntity in #6)
- SimEntity.Reset() pulisce solo i riferimenti: i value-type vengono riscritti da Spawn al riuso dal pool, eliminando la duplicazione della lista campi tra Spawn e Reset
- Rimuove commenti WHAT da SimEntity (i nomi sono già descrittivi)
- EntityManager espone Active come IReadOnlyDictionary per consentire lookup O(1) ai consumer senza esporre il dizionario interno mutabile
- SimulationEngine.GetStateDelta() evita ToDictionary + roundtrip: itera direttamente su Active e aggiorna _knownEntityIds in-place con Add/RemoveWhere, riducendo allocazioni nell'hot path del tick