### PR TITLE
[F0] Completa SimulationState e StateDelta (#8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,13 @@ Stockflow.Webserver
 
 Issues tracked at `mcauzzi/Stockflow`. Organised by milestone: F0 (foundations, current), F1A–D, F2, F3.
 
+**Branch workflow:** main is kept up to date via rebase. Always create feature branches from `origin/main` after a `git fetch`:
+
+```bash
+git fetch origin main
+git checkout -b claude/issue-N-short-desc origin/main
+```
+
 ### Documentation
 
 Detailed design documents (in Italian) are in `Docs/`:

--- a/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
+++ b/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
@@ -6,8 +6,9 @@ namespace Stockflow.Simulation.Core;
 
 public class SimulationEngine
 {
-    private HashSet<int> _knownComponentIds = new();
-    private HashSet<int> _knownEntityIds    = new();
+    private HashSet<int>             _knownComponentIds = new();
+    private HashSet<int>             _knownEntityIds    = new();
+    private Dictionary<int, EntityState> _lastEntityStates  = new();
 
     public SimulationEngine(int width, int length, int height)
     {
@@ -36,7 +37,6 @@ public class SimulationEngine
         return CommandResult.Fail($"Unknown command: {command.GetType().Name}");
     }
 
-    // Ritorna le differenze rispetto all'ultima chiamata — verrà espanso con delta completo (#8)
     public StateDelta GetStateDelta()
     {
         var currentComponents = State.Components.Select(c => c.Id).ToHashSet();
@@ -44,17 +44,30 @@ public class SimulationEngine
         var removedComponents = _knownComponentIds.Except(currentComponents).ToList();
         _knownComponentIds = currentComponents;
 
-        var currentEntities = State.Entities.Active;
-        var addedEntities   = new List<EntityState>();
+        var currentEntities  = State.Entities.Active;
+        var addedEntities    = new List<EntityState>();
+        var updatedEntities  = new List<EntityState>();
+
         foreach (var (id, entity) in currentEntities)
+        {
+            var snapshot = EntityState.From(entity);
             if (_knownEntityIds.Add(id))
-                addedEntities.Add(EntityState.From(entity));
+            {
+                addedEntities.Add(snapshot);
+            }
+            else if (_lastEntityStates.TryGetValue(id, out var prev) && prev != snapshot)
+            {
+                updatedEntities.Add(snapshot);
+            }
+            _lastEntityStates[id] = snapshot;
+        }
 
         var removedEntities = new List<int>();
         _knownEntityIds.RemoveWhere(id =>
         {
             if (currentEntities.ContainsKey(id)) return false;
             removedEntities.Add(id);
+            _lastEntityStates.Remove(id);
             return true;
         });
 
@@ -64,6 +77,7 @@ public class SimulationEngine
             AddedComponentIds   = addedComponents,
             RemovedComponentIds = removedComponents,
             AddedEntityStates   = addedEntities,
+            UpdatedEntityStates = updatedEntities,
             RemovedEntityIds    = removedEntities,
         };
     }

--- a/Sources/Stockflow.Simulation/Core/SimulationEvent.cs
+++ b/Sources/Stockflow.Simulation/Core/SimulationEvent.cs
@@ -1,0 +1,15 @@
+namespace Stockflow.Simulation.Core;
+
+public enum SimulationEventType
+{
+    EntityTransferred,  // un'entità è passata da un componente al successivo
+    ConveyorJammed,     // un'entità non ha potuto uscire per capacità piena
+}
+
+// Evento discreto generato durante un tick — incluso nel delta per audit/animazioni client
+public sealed class SimulationEvent
+{
+    public SimulationEventType Type        { get; init; }
+    public int                 EntityId    { get; init; }
+    public int?                ComponentId { get; init; }
+}

--- a/Sources/Stockflow.Simulation/Core/StateDelta.cs
+++ b/Sources/Stockflow.Simulation/Core/StateDelta.cs
@@ -2,12 +2,14 @@ using Stockflow.Simulation.Entity;
 
 namespace Stockflow.Simulation.Core;
 
-// Delta tra due tick consecutivi — verrà espanso con delta completo (#8)
+// Delta tra due tick consecutivi — struttura fondamentale per comunicazione server→client
 public sealed class StateDelta
 {
-    public float                    SimulationTime      { get; init; }
-    public IReadOnlyList<int>       AddedComponentIds   { get; init; } = [];
-    public IReadOnlyList<int>       RemovedComponentIds { get; init; } = [];
-    public IReadOnlyList<EntityState> AddedEntityStates   { get; init; } = [];
-    public IReadOnlyList<int>       RemovedEntityIds    { get; init; } = [];
+    public float                         SimulationTime      { get; init; }
+    public IReadOnlyList<int>            AddedComponentIds   { get; init; } = [];
+    public IReadOnlyList<int>            RemovedComponentIds { get; init; } = [];
+    public IReadOnlyList<EntityState>    AddedEntityStates   { get; init; } = [];
+    public IReadOnlyList<EntityState>    UpdatedEntityStates { get; init; } = [];
+    public IReadOnlyList<int>            RemovedEntityIds    { get; init; } = [];
+    public IReadOnlyList<SimulationEvent> Events             { get; init; } = [];
 }

--- a/Sources/Stockflow.Simulation/Entity/EntityState.cs
+++ b/Sources/Stockflow.Simulation/Entity/EntityState.cs
@@ -2,8 +2,9 @@ using Stockflow.Simulation.Component;
 
 namespace Stockflow.Simulation.Entity;
 
-// Snapshot serializzabile per sincronizzazione di rete — solo tipi primitivi
-public sealed class EntityState
+// Snapshot serializzabile per sincronizzazione di rete — solo tipi primitivi.
+// Record per equality strutturale: due snapshot uguali campo per campo sono identici.
+public sealed record EntityState
 {
     public int          Id                 { get; init; }
     public string       Sku                { get; init; } = "";


### PR DESCRIPTION
- EntityState diventa record: equality strutturale gratuita usata da GetStateDelta() per rilevare le entità aggiornate senza confronti campo per campo espliciti
- Aggiunge SimulationEvent con tipo enum (EntityTransferred, ConveyorJammed) — infrastruttura eventi per audit/animazioni client
- StateDelta espone UpdatedEntityStates (entità già note con stato cambiato) ed Events, completando la struttura delta server→client descritta in ARCHITECTURE §4.3 e §6.2
- GetStateDelta() traccia _lastEntityStates per rilevare aggiornamenti in O(n) senza allocazioni extra; rimuove anche lo snapshot al despawn dell'entità
- Aggiorna CLAUDE.md con la convenzione branching (sempre da origin/main)