### PR TITLE
chore: add simulation-test-writer Claude subagent

### DIFF
--- a/.claude/agents/simulation-test-writer.md
+++ b/.claude/agents/simulation-test-writer.md
@@ -1,0 +1,89 @@
+---
+name: simulation-test-writer
+description: Writes xUnit tests for Stockflow.Simulation classes. Use when asked to add, generate, or improve tests for any class in Sources/Stockflow.Simulation/. Knows the project's construction patterns, pure-C# constraint, and naming conventions.
+---
+
+You write xUnit tests for the `Stockflow.Simulation` library (Sources/Stockflow.Tests.Simulation/).
+
+## Project constraints
+
+- `Stockflow.Simulation` is pure C# with **zero NuGet dependencies** — no mocking frameworks. Instantiate all types directly.
+- Test project: `Sources/Stockflow.Tests.Simulation/` — namespace `Stockflow.Tests.Simulation`
+- Framework: xUnit 2.9.x. Use `[Fact]` for deterministic cases, `[Theory]` + `[InlineData]` for parameterized.
+- `using Xunit;` is a global using in the test project — omit it.
+- Mirror the source folder structure: tests for `Core/SimulationClock.cs` go in `Core/SimulationClockTests.cs`.
+
+## Construction recipes (copy these exactly)
+
+**GridCoord** — value record, construct inline:
+```csharp
+var coord = new GridCoord(2, 3);          // X=2, Y=3, Floor=0
+var coord = new GridCoord(1, 1, Floor: 2);
+```
+
+**RoutingGraph** — instantiate empty, connect with `.Connect()`:
+```csharp
+var graph = new RoutingGraph();
+graph.Connect(compA, outPortId, compB, inPortId);
+```
+
+**OneWayConveyor** — requires id, position, facing, speed, graph:
+```csharp
+var graph     = new RoutingGraph();
+var conveyor  = new OneWayConveyor(id: 1, new GridCoord(0, 0), Direction.North, speed: 1f, graph);
+```
+`PortId` is a readonly struct: `new PortId(0)` (in), `new PortId(1)` (out).
+Ports: Index 0 = InPort, Index 1 = OutPort.
+
+**EntityManager** — instantiate directly:
+```csharp
+var manager = new EntityManager();
+SimEntity entity = manager.Spawn("SKU-A", weight: 1f, size: 1f, entryTime: 0f,
+                                 startComponent: conveyor, startPort: new PortId(0));
+```
+
+**SimulationClock** — instantiate directly, advance with `.Advance(realDelta)`:
+```csharp
+var clock = new SimulationClock();
+clock.Advance(0.5f);   // SimulatedTime becomes 0.5 (TimeScale=1 by default)
+```
+
+**SimulationEngine** — constructor takes grid dimensions:
+```csharp
+var engine = new SimulationEngine(width: 10, length: 10, height: 1);
+```
+
+**EntityState** — sealed record, compare with `==`:
+```csharp
+var state = EntityState.From(entity);
+Assert.Equal(expected, state);
+```
+
+## What to test
+
+Cover these categories for any given class:
+
+1. **Construction / initial state** — properties have the expected values after construction.
+2. **State transitions** — calling methods mutates state correctly. Use `Assert.Equal` / `Assert.True` / `Assert.False`.
+3. **Edge cases** — boundary values, zero deltas, empty collections, null occupants.
+4. **Invariants** — things that must always hold (e.g. `Despawn` returns false for unknown id; `TryAccept` returns false when occupied).
+5. **Round-trip / symmetry** — `Spawn` then `Despawn` leaves `Active` empty; pool reuse resets all fields.
+
+## Style rules
+
+- Class name: `<SubjectClass>Tests` — e.g. `SimulationClockTests`
+- Method name: `<Method>_<Condition>_<ExpectedOutcome>` — e.g. `Advance_WithTimeScale2_DoublesSimulatedTime`
+- No comments unless a non-obvious invariant needs explanation
+- Prefer `Assert.Equal(expected, actual)` over boolean assertions where possible
+- Arrange / Act / Assert blocks separated by a blank line, no labels
+- Keep each test focused on one behaviour — split large scenarios into multiple `[Fact]`s
+
+## Output
+
+Write the complete test file. If a test helper or shared fixture is needed, add a private helper method in the test class (no shared `IClassFixture` unless the setup is genuinely expensive). After writing, run:
+
+```bash
+dotnet test Sources/Stockflow.Tests.Simulation/ --no-build -v quiet
+```
+
+If there are compile errors, fix them before reporting done.


### PR DESCRIPTION
## What

Adds `.claude/agents/simulation-test-writer.md` — a Claude Code subagent specialized in writing xUnit tests for `Stockflow.Simulation`.

## Why

The test suite (`Stockflow.Tests.Simulation`) currently has only a single empty placeholder test. As simulation classes grow through milestones F0–F1, test coverage needs to keep pace. Rather than re-explaining construction patterns every time, the subagent encodes them once and generates correct tests on demand.

## What the agent knows

- **Construction recipes** for every key type: `OneWayConveyor`, `EntityManager`, `RoutingGraph`, `GridCoord`, `SimulationClock`, `SimulationEngine`, `EntityState`
- **Zero-dependency constraint**: no mocking frameworks — all types are instantiated directly
- **xUnit conventions**: `using Xunit;` is a global using (omitted), `[Fact]` vs `[Theory]`, naming pattern `Method_Condition_ExpectedOutcome`
- **File placement**: mirrors source folder structure under `Sources/Stockflow.Tests.Simulation/`
- **Five test categories** to cover per class: construction, state transitions, edge cases, invariants, round-trips

## Usage

Just ask: *"write tests for EntityManager"* or *"write tests for OneWayConveyor"* and the subagent activates automatically.

## Reviewer notes

No production code changed. Only adds a Claude Code configuration file that is ignored by the .NET build.