### PR TITLE
[F0] Stockflow.Protocol — messaggi e tipi condivisi (#9)

### DIFF
--- a/Sources/Stockflow.Protocol/Class1.cs
+++ b/Sources/Stockflow.Protocol/Class1.cs
@@ -1,5 +1,0 @@
-﻿namespace Stockflow.Protocol;
-
-public class Class1
-{
-}

--- a/Sources/Stockflow.Protocol/Messages/ClientMessages.cs
+++ b/Sources/Stockflow.Protocol/Messages/ClientMessages.cs
@@ -1,0 +1,75 @@
+using MessagePack;
+
+namespace Stockflow.Protocol.Messages;
+
+/// <summary>
+/// Base type for every message a client sends to the server.
+/// Each concrete subtype is registered as a MessagePack Union — the discriminator byte
+/// is part of the wire format, never renumber existing entries.
+/// </summary>
+[Union(0, typeof(PlaceComponentMessage))]
+[Union(1, typeof(RemoveComponentMessage))]
+[Union(2, typeof(ConfigureComponentMessage))]
+[Union(3, typeof(ChangeSpeedMessage))]
+[Union(4, typeof(RequestFullStateMessage))]
+[MessagePackObject]
+public abstract class ClientMessage
+{
+    /// <summary>
+    /// Client-generated correlation id. The server echoes it back in <c>CommandResultMessage</c>
+    /// so the client can match the response with the originating command.
+    /// </summary>
+    [Key(0)] public int CommandId { get; init; }
+}
+
+/// <summary>
+/// Ask the server to place a new component at the given grid cell facing a given direction.
+/// </summary>
+[MessagePackObject]
+public sealed class PlaceComponentMessage : ClientMessage
+{
+    [Key(1)] public ComponentType ComponentType { get; init; }
+    [Key(2)] public int           GridX         { get; init; }
+    [Key(3)] public int           GridY         { get; init; }
+    [Key(4)] public Direction     Direction     { get; init; }
+}
+
+/// <summary>
+/// Ask the server to remove the component with the given id.
+/// </summary>
+[MessagePackObject]
+public sealed class RemoveComponentMessage : ClientMessage
+{
+    [Key(1)] public int ComponentId { get; init; }
+}
+
+/// <summary>
+/// Update loose properties on an existing component (speed, priority, routing rule…).
+/// Properties are free-form strings so new fields can ship without a protocol bump —
+/// the server parses them per component type.
+/// </summary>
+[MessagePackObject]
+public sealed class ConfigureComponentMessage : ClientMessage
+{
+    [Key(1)] public int                        ComponentId { get; init; }
+    [Key(2)] public Dictionary<string, string> Properties  { get; init; } = new();
+}
+
+/// <summary>
+/// Request a new simulation speed. The server may refuse (returns <c>Success=false</c>)
+/// if a WMS session forces <see cref="SimSpeed.Live"/>.
+/// </summary>
+[MessagePackObject]
+public sealed class ChangeSpeedMessage : ClientMessage
+{
+    [Key(1)] public SimSpeed Speed { get; init; }
+}
+
+/// <summary>
+/// Request an authoritative full state resync (e.g. after a checksum mismatch or reconnect).
+/// The server replies with a <c>FullStateMessage</c>.
+/// </summary>
+[MessagePackObject]
+public sealed class RequestFullStateMessage : ClientMessage
+{
+}

--- a/Sources/Stockflow.Protocol/Messages/ClientMessages.cs
+++ b/Sources/Stockflow.Protocol/Messages/ClientMessages.cs
@@ -28,10 +28,10 @@ public abstract class ClientMessage
 [MessagePackObject]
 public sealed class PlaceComponentMessage : ClientMessage
 {
-    [Key(1)] public ComponentType ComponentType { get; init; }
-    [Key(2)] public int           GridX         { get; init; }
-    [Key(3)] public int           GridY         { get; init; }
-    [Key(4)] public Direction     Direction     { get; init; }
+    [Key(1)] public string    Kind      { get; init; } = "";
+    [Key(2)] public int       GridX     { get; init; }
+    [Key(3)] public int       GridY     { get; init; }
+    [Key(4)] public Direction Direction { get; init; }
 }
 
 /// <summary>

--- a/Sources/Stockflow.Protocol/Messages/ServerMessages.cs
+++ b/Sources/Stockflow.Protocol/Messages/ServerMessages.cs
@@ -1,0 +1,70 @@
+using MessagePack;
+
+namespace Stockflow.Protocol.Messages;
+
+/// <summary>
+/// Base type for every message the server sends to connected clients over the WebSocket.
+/// MessagePack [Union] serialises the concrete subtype automatically — callers deserialise
+/// as ServerMessage and pattern-match on the result.
+/// Union keys are part of the wire format; never renumber an existing entry.
+/// </summary>
+[Union(0, typeof(StateDeltaMessage))]
+[Union(1, typeof(FullStateMessage))]
+[Union(2, typeof(CommandResultMessage))]
+[MessagePackObject]
+public abstract class ServerMessage
+{
+    /// <summary>Server wall-clock time (seconds since start) for latency diagnostics.</summary>
+    [Key(0)] public float ServerTime { get; init; }
+}
+
+/// <summary>
+/// Delta between two consecutive simulation ticks. The default per-tick broadcast carries
+/// only what has changed — see Docs/ARCHITECTURE §7.3 and §12.3 for size budgets.
+/// </summary>
+[MessagePackObject]
+public sealed class StateDeltaMessage : ServerMessage
+{
+    [Key(1)] public float SimulationTime { get; init; }
+    [Key(2)] public float TimeScale      { get; init; }
+
+    [Key(3)] public EntityState[]    UpdatedEntities    { get; init; } = [];
+    [Key(4)] public EntityState[]    CreatedEntities    { get; init; } = [];
+    [Key(5)] public int[]            RemovedEntityIds   { get; init; } = [];
+
+    [Key(6)] public ComponentState[] UpdatedComponents  { get; init; } = [];
+    [Key(7)] public ComponentState[] CreatedComponents  { get; init; } = [];
+    [Key(8)] public int[]            RemovedComponentIds { get; init; } = [];
+
+    [Key(9)]  public SimEvent[]       Events  { get; init; } = [];
+    [Key(10)] public MetricsSnapshot? Metrics { get; init; }
+
+    /// <summary>Optional rolling checksum of the full state, emitted every N ticks for desync detection.</summary>
+    [Key(11)] public uint? StateChecksum { get; init; }
+}
+
+/// <summary>
+/// Full authoritative snapshot. Sent on initial connection and whenever a client asks to
+/// resync (see <see cref="RequestFullStateMessage"/>). Much larger than a delta; use sparingly.
+/// </summary>
+[MessagePackObject]
+public sealed class FullStateMessage : ServerMessage
+{
+    [Key(1)] public float            SimulationTime { get; init; }
+    [Key(2)] public float            TimeScale      { get; init; }
+    [Key(3)] public EntityState[]    Entities       { get; init; } = [];
+    [Key(4)] public ComponentState[] Components     { get; init; } = [];
+    [Key(5)] public MetricsSnapshot? Metrics        { get; init; }
+}
+
+/// <summary>
+/// Ack/nack for a command previously sent by the client.
+/// The server echoes the client-supplied <c>CommandId</c> so the client can correlate.
+/// </summary>
+[MessagePackObject]
+public sealed class CommandResultMessage : ServerMessage
+{
+    [Key(1)] public int     CommandId    { get; init; }
+    [Key(2)] public bool    Success      { get; init; }
+    [Key(3)] public string? ErrorMessage { get; init; }
+}

--- a/Sources/Stockflow.Protocol/Messages/SharedTypes.cs
+++ b/Sources/Stockflow.Protocol/Messages/SharedTypes.cs
@@ -1,0 +1,118 @@
+using MessagePack;
+
+namespace Stockflow.Protocol.Messages;
+
+/// <summary>
+/// 3D vector used for entity world-space positions sent to rendering clients.
+/// The simulation itself represents position graph-based (component + port + progress);
+/// the Webserver converts to Vector3 before broadcasting to clients.
+/// </summary>
+[MessagePackObject]
+public readonly struct Vector3
+{
+    [Key(0)] public float X { get; init; }
+    [Key(1)] public float Y { get; init; }
+    [Key(2)] public float Z { get; init; }
+
+    public Vector3(float x, float y, float z) { X = x; Y = y; Z = z; }
+
+    public static Vector3 Zero => new(0f, 0f, 0f);
+}
+
+/// <summary>
+/// Component kind. Kept as a Protocol-local enum (not a reference to the Simulation one)
+/// so Unity clients can import only Stockflow.Protocol.dll.
+/// Keep numeric values stable across releases — they are part of the wire format.
+/// </summary>
+public enum ComponentType : byte
+{
+    OneWayConveyor = 0,
+}
+
+/// <summary>
+/// Cardinal direction a component faces. Wire-stable byte values.
+/// </summary>
+public enum Direction : byte
+{
+    North = 0,
+    East  = 1,
+    South = 2,
+    West  = 3,
+}
+
+/// <summary>
+/// Runtime status of a simulated entity (load unit). Wire-stable byte values.
+/// </summary>
+public enum EntityStatus : byte
+{
+    Idle   = 0,
+    Moving = 1,
+    Queued = 2,
+}
+
+/// <summary>
+/// Simulation playback speed requested by the client. The server decides the actual
+/// TimeScale multiplier; this enum only carries the user's intent.
+/// Live forces 1x and is reserved for WMS-connected sessions.
+/// </summary>
+public enum SimSpeed : byte
+{
+    Paused    = 0,
+    Normal    = 1,  // 1x
+    Fast      = 2,  // 2x
+    Faster    = 3,  // 5x
+    UltraFast = 4,  // 10x
+    Live      = 5,  // 1x locked, B2B mode
+}
+
+/// <summary>
+/// Network snapshot of a single entity. Sent inside StateDeltaMessage and FullStateMessage.
+/// World-space position is precomputed server-side for client rendering.
+/// </summary>
+[MessagePackObject]
+public sealed record EntityState
+{
+    [Key(0)] public int          Id       { get; init; }
+    [Key(1)] public string       Sku      { get; init; } = "";
+    [Key(2)] public Vector3      Position { get; init; }
+    [Key(3)] public EntityStatus Status   { get; init; }
+}
+
+/// <summary>
+/// Network snapshot of a placed component.
+/// </summary>
+[MessagePackObject]
+public sealed record ComponentState
+{
+    [Key(0)] public int           Id     { get; init; }
+    [Key(1)] public ComponentType Type   { get; init; }
+    [Key(2)] public int           GridX  { get; init; }
+    [Key(3)] public int           GridY  { get; init; }
+    [Key(4)] public Direction     Facing { get; init; }
+}
+
+/// <summary>
+/// Generic simulation event (entity spawned, order completed, collision…).
+/// Payload is opaque JSON so new event kinds can ship without bumping the protocol.
+/// </summary>
+[MessagePackObject]
+public sealed record SimEvent
+{
+    [Key(0)] public string EventType  { get; init; } = "";
+    [Key(1)] public float  SimTime    { get; init; }
+    [Key(2)] public string PayloadJson { get; init; } = "";
+}
+
+/// <summary>
+/// Aggregate KPI snapshot attached to each StateDeltaMessage so clients can update HUDs
+/// without hitting the REST endpoint.
+/// </summary>
+[MessagePackObject]
+public sealed record MetricsSnapshot
+{
+    [Key(0)] public double Throughput         { get; init; }
+    [Key(1)] public double AvgFulfillmentTime { get; init; }
+    [Key(2)] public double WarehouseSaturation { get; init; }
+    [Key(3)] public int    ActiveOrders       { get; init; }
+    [Key(4)] public int    CompletedOrders    { get; init; }
+}

--- a/Sources/Stockflow.Protocol/Messages/SharedTypes.cs
+++ b/Sources/Stockflow.Protocol/Messages/SharedTypes.cs
@@ -20,13 +20,15 @@ public readonly struct Vector3
 }
 
 /// <summary>
-/// Component kind. Kept as a Protocol-local enum (not a reference to the Simulation one)
-/// so Unity clients can import only Stockflow.Protocol.dll.
-/// Keep numeric values stable across releases — they are part of the wire format.
+/// Component kind identifier used on the wire. A plain string (not an enum) because the
+/// set of component types is open: the plugin system registers new kinds at runtime, and
+/// scenario JSON already uses kind strings ("conveyor_oneway", "stacker_crane", ...).
+/// Once a kind ships in a release its string value is part of the wire contract — do not
+/// rename.
 /// </summary>
-public enum ComponentType : byte
+public static class ComponentKinds
 {
-    OneWayConveyor = 0,
+    public const string OneWayConveyor = "conveyor_oneway";
 }
 
 /// <summary>
@@ -84,11 +86,11 @@ public sealed record EntityState
 [MessagePackObject]
 public sealed record ComponentState
 {
-    [Key(0)] public int           Id     { get; init; }
-    [Key(1)] public ComponentType Type   { get; init; }
-    [Key(2)] public int           GridX  { get; init; }
-    [Key(3)] public int           GridY  { get; init; }
-    [Key(4)] public Direction     Facing { get; init; }
+    [Key(0)] public int       Id     { get; init; }
+    [Key(1)] public string    Kind   { get; init; } = "";
+    [Key(2)] public int       GridX  { get; init; }
+    [Key(3)] public int       GridY  { get; init; }
+    [Key(4)] public Direction Facing { get; init; }
 }
 
 /// <summary>

--- a/Sources/Stockflow.Protocol/README.md
+++ b/Sources/Stockflow.Protocol/README.md
@@ -129,7 +129,12 @@ All clients include a client-generated `CommandId`; the server echoes it back in
 
 - `Vector3` — world-space position (server converts from its graph-based representation
   before broadcasting).
-- `ComponentType`, `Direction`, `EntityStatus`, `SimSpeed` — wire-stable `byte` enums.
+- `Direction`, `EntityStatus`, `SimSpeed` — wire-stable `byte` enums (closed sets that
+  won't grow with plugins).
+- `ComponentKinds` — static string constants for built-in component kinds. Components
+  travel on the wire as `string Kind` rather than an enum so plugins can register new
+  kinds without recompiling `Stockflow.Protocol`; once a kind string ships it becomes
+  part of the wire contract and must not be renamed.
 - `EntityState`, `ComponentState`, `SimEvent`, `MetricsSnapshot` — DTOs embedded in
   `StateDeltaMessage` / `FullStateMessage`.
 
@@ -206,7 +211,11 @@ Deltas typically compress another 2–3× on top of MessagePack's binary layout.
    with it.
 4. **Enum values are bytes with stable ordering.** Never reorder, never reuse a removed
    value. Add new enum members at the end.
-5. **Adding a new message type:** allocate the next unused `Union` tag on the relevant
+5. **Component kinds (strings) are wire contracts too.** Once `"conveyor_oneway"` ships,
+   it is immutable. Pick the string carefully the first time; add new kinds with new
+   strings; never silently alias or rename. Plugins are expected to namespace their kinds
+   (e.g. `"acme.custom_sorter"`) to avoid collisions with core.
+6. **Adding a new message type:** allocate the next unused `Union` tag on the relevant
    base class, add the `[MessagePackObject]` subclass, done. Old peers that don't know
    the tag will throw on deserialize — that's the designed behaviour.
 

--- a/Sources/Stockflow.Protocol/README.md
+++ b/Sources/Stockflow.Protocol/README.md
@@ -1,0 +1,221 @@
+# Stockflow.Protocol
+
+Shared wire-format library. Everything that travels on the WebSocket between the Stockflow
+server and a client (Unity, web dashboard, CLI, WMS adapter) is defined here.
+
+This is the **only** project the clients are expected to reference — it contains no
+simulation logic and no ASP.NET dependencies, just DTOs and MessagePack configuration.
+
+---
+
+## 1. Why MessagePack?
+
+MessagePack is a binary serialization format — think "JSON, but smaller and faster, encoded
+as bytes". It was chosen over JSON for the WebSocket channel because:
+
+| Metric                       | JSON          | MessagePack   |
+|------------------------------|---------------|---------------|
+| Size (100-entity delta)      | 10–25 KB      | 2–5 KB        |
+| Serialize / deserialize time | baseline      | 5–10× faster  |
+| Binary payloads              | base64 only   | native        |
+| Schema on the wire           | field names   | integer keys  |
+
+The ASP.NET REST endpoints still use JSON — human readability matters there, and the volume
+is low. MessagePack is only on the high-frequency WebSocket channel.
+
+Library used: **[MessagePack-CSharp](https://github.com/MessagePack-CSharp/MessagePack-CSharp)**
+(package `MessagePack`). The same package works in Unity, so clients can deserialize
+with zero code duplication.
+
+---
+
+## 2. The three attributes you need to know
+
+### `[MessagePackObject]` — marks a class or struct as serializable
+
+Every message type we send across the wire carries this attribute. It signals to the
+MessagePack source generator that the type participates in serialization.
+
+```csharp
+[MessagePackObject]
+public sealed class PlaceComponentMessage : ClientMessage { ... }
+```
+
+### `[Key(n)]` — assigns an integer tag to a field
+
+Instead of storing field names (`"GridX"`, `"GridY"` …) on the wire, MessagePack stores
+integer tags. That is the main reason payloads are 2–5× smaller than JSON.
+
+```csharp
+[Key(0)] public int GridX { get; init; }
+[Key(1)] public int GridY { get; init; }
+```
+
+**Golden rule:** once a field ships in a release, its `Key` number is frozen forever.
+Reordering, renumbering, or repurposing a key silently corrupts data for any peer running
+an older build. New fields go on **new, unused** numbers. Removed fields leave their number
+reserved (add a comment so nobody reuses it).
+
+Keys inside a subclass start at `1` because `Key(0)` is already taken by the base class
+(`ServerTime` for `ServerMessage`, `CommandId` for `ClientMessage`). Keep that offset in
+mind when adding new members.
+
+### `[Union(tag, typeof(Subclass))]` — polymorphism
+
+A base class annotated with `[Union]` entries can be serialized and deserialized as any of
+its registered subtypes. The tag (a small integer) is written on the wire as a
+discriminator; the deserializer picks the right concrete type automatically.
+
+```csharp
+[Union(0, typeof(StateDeltaMessage))]
+[Union(1, typeof(FullStateMessage))]
+[Union(2, typeof(CommandResultMessage))]
+public abstract class ServerMessage { ... }
+```
+
+A receiver does:
+
+```csharp
+ServerMessage msg = MessagePackSerializer.Deserialize<ServerMessage>(buffer, options);
+switch (msg)
+{
+    case StateDeltaMessage delta:    /* apply delta */ break;
+    case FullStateMessage full:      /* rebuild visuals */ break;
+    case CommandResultMessage ack:   /* correlate via ack.CommandId */ break;
+}
+```
+
+**Same compatibility rule as `Key`:** union tags are frozen once shipped. New message types
+go on new tag numbers.
+
+---
+
+## 3. What's in the box
+
+```
+Stockflow.Protocol/
+├── Messages/
+│   ├── SharedTypes.cs         ← Vector3, enums, state DTOs used by messages
+│   ├── ServerMessages.cs      ← Server → Client
+│   └── ClientMessages.cs      ← Client → Server
+└── Serialization/
+    └── MessagePackConfig.cs   ← One-shot options/resolver setup
+```
+
+### 3.1 — Server → Client messages
+
+| Message                | Union tag | When sent                                                |
+|------------------------|-----------|----------------------------------------------------------|
+| `StateDeltaMessage`    | 0         | Every tick (10–100 Hz). Only what changed.               |
+| `FullStateMessage`     | 1         | Initial connection, after desync, on `RequestFullState`. |
+| `CommandResultMessage` | 2         | Ack/nack for a client command, echoing its `CommandId`.  |
+
+### 3.2 — Client → Server messages
+
+| Message                     | Union tag | Purpose                                          |
+|-----------------------------|-----------|--------------------------------------------------|
+| `PlaceComponentMessage`     | 0         | Put a new component on the grid.                 |
+| `RemoveComponentMessage`    | 1         | Delete an existing component by id.              |
+| `ConfigureComponentMessage` | 2         | Change loose properties on a component.          |
+| `ChangeSpeedMessage`        | 3         | Pause / 1x / 2x / 5x / 10x / Live.               |
+| `RequestFullStateMessage`   | 4         | Ask the server for a fresh full snapshot.        |
+
+All clients include a client-generated `CommandId`; the server echoes it back in
+`CommandResultMessage` so the client can correlate request and response.
+
+### 3.3 — Shared types
+
+`SharedTypes.cs` holds everything the messages *contain*:
+
+- `Vector3` — world-space position (server converts from its graph-based representation
+  before broadcasting).
+- `ComponentType`, `Direction`, `EntityStatus`, `SimSpeed` — wire-stable `byte` enums.
+- `EntityState`, `ComponentState`, `SimEvent`, `MetricsSnapshot` — DTOs embedded in
+  `StateDeltaMessage` / `FullStateMessage`.
+
+---
+
+## 4. Using the library
+
+### 4.1 — One-time startup
+
+Call `MessagePackConfig.Initialize()` once, before anything is serialized. It's idempotent,
+so it's safe to call from multiple entry points.
+
+```csharp
+// In the server's Program.cs, or a Unity bootstrap MonoBehaviour's Awake()
+Stockflow.Protocol.Serialization.MessagePackConfig.Initialize();
+```
+
+After this, the configured `MessagePackSerializerOptions` are both available as
+`MessagePackConfig.Options` and installed as `MessagePackSerializer.DefaultOptions`.
+
+### 4.2 — Sending (server side)
+
+```csharp
+var delta = new StateDeltaMessage
+{
+    ServerTime     = (float)stopwatch.Elapsed.TotalSeconds,
+    SimulationTime = engine.Clock.SimulationTime,
+    TimeScale      = engine.TimeScale,
+    CreatedEntities = newEntities,
+    UpdatedEntities = movedEntities,
+    RemovedEntityIds = deadIds,
+    // ...
+};
+
+// Serialize the BASE type so the union tag is written.
+byte[] payload = MessagePackSerializer.Serialize<ServerMessage>(delta);
+await socket.SendAsync(payload, WebSocketMessageType.Binary, ...);
+```
+
+**Always serialize against the base class (`ServerMessage` / `ClientMessage`)** so the
+discriminator lands on the wire. Serializing against the concrete subtype skips the union
+header, and the receiver won't be able to tell the messages apart.
+
+### 4.3 — Receiving (client side)
+
+```csharp
+var msg = MessagePackSerializer.Deserialize<ServerMessage>(buffer.AsMemory(0, count));
+switch (msg)
+{
+    case FullStateMessage f:     stateBuffer.ApplyFullState(f); break;
+    case StateDeltaMessage d:    stateBuffer.ApplyDelta(d);     break;
+    case CommandResultMessage r: pending.Resolve(r);            break;
+}
+```
+
+### 4.4 — LZ4 compression is automatic
+
+`MessagePackConfig` enables `Lz4BlockArray` compression. You do nothing different — the
+library compresses on serialize and decompresses on deserialize as long as both peers use
+the same options (which they will, since they both call `MessagePackConfig.Initialize`).
+
+Deltas typically compress another 2–3× on top of MessagePack's binary layout.
+
+---
+
+## 5. Evolution rules (do not break the wire)
+
+1. **Never renumber an existing `Key` or `Union` tag.** Append only.
+2. **Never change an existing field's type.** Add a new field on a new key.
+3. **Don't rely on field initializers to provide default values after deserialization.**
+   If a sender legitimately omits a field (new sender, old field), the receiver gets
+   `default(T)`, not the initializer value. In practice we always write every key, so this
+   is a theoretical concern — but if you ever split the protocol across versions, reckon
+   with it.
+4. **Enum values are bytes with stable ordering.** Never reorder, never reuse a removed
+   value. Add new enum members at the end.
+5. **Adding a new message type:** allocate the next unused `Union` tag on the relevant
+   base class, add the `[MessagePackObject]` subclass, done. Old peers that don't know
+   the tag will throw on deserialize — that's the designed behaviour.
+
+---
+
+## 6. Cross-reference
+
+- Architecture doc: [`Docs/ARCHITECTURE_StockFlow_v0.3.md`](../../Docs/ARCHITECTURE_StockFlow_v0.3.md)
+  — §4.2 tick/network boundary, §7 protocol, §8 comms cycle, §12 latency & size budgets,
+  §13 desync detection.
+- Originating issue: [#9](https://github.com/mcauzzi/Stockflow/issues/9) —
+  *StockFlow.Protocol — messaggi e tipi condivisi*.

--- a/Sources/Stockflow.Protocol/Serialization/MessagePackConfig.cs
+++ b/Sources/Stockflow.Protocol/Serialization/MessagePackConfig.cs
@@ -1,0 +1,61 @@
+using MessagePack;
+using MessagePack.Resolvers;
+
+namespace Stockflow.Protocol.Serialization;
+
+/// <summary>
+/// Centralised MessagePack configuration shared by every process that speaks the Stockflow
+/// wire protocol (server, Unity client, web client, CLI).
+///
+/// <para>Call <see cref="Initialize"/> once during startup before serializing anything. Subsequent
+/// calls are no-ops. The configured <see cref="Options"/> are also installed as
+/// <see cref="MessagePackSerializer.DefaultOptions"/> so code that does not explicitly pass
+/// options still picks them up.</para>
+///
+/// <para>Design choices:</para>
+/// <list type="bullet">
+///   <item><description><b>StandardResolver</b> — our DTOs use explicit <c>[Key]</c> attributes, which the
+///     standard resolver handles out of the box. Do not switch to <c>ContractlessStandardResolver</c>:
+///     name-based keys are fragile under refactoring and fatter on the wire.</description></item>
+///   <item><description><b>LZ4 block-array compression</b> — deltas compress 2-3x with negligible CPU
+///     cost; the WebSocket broadcast benefits directly. Both peers must agree, which is why
+///     compression is set here and nowhere else.</description></item>
+///   <item><description><b>No custom formatters (yet)</b> — add them to the <c>CompositeResolver</c>
+///     below when introducing types the standard resolver cannot handle (e.g. third-party structs).</description></item>
+/// </list>
+/// </summary>
+public static class MessagePackConfig
+{
+    private static readonly object _lock = new();
+    private static bool _initialized;
+
+    /// <summary>
+    /// Serializer options used for every message on the Stockflow WebSocket channel.
+    /// Until <see cref="Initialize"/> is called this holds the library's untouched defaults;
+    /// after initialisation it carries the Stockflow resolver and LZ4 compression.
+    /// </summary>
+    public static MessagePackSerializerOptions Options { get; private set; }
+        = MessagePackSerializerOptions.Standard;
+
+    /// <summary>
+    /// Idempotent startup hook. Safe to call from multiple entry points (server, test host, tools).
+    /// </summary>
+    public static void Initialize()
+    {
+        if (_initialized) return;
+        lock (_lock)
+        {
+            if (_initialized) return;
+
+            var resolver = CompositeResolver.Create(
+                StandardResolver.Instance);
+
+            Options = MessagePackSerializerOptions.Standard
+                .WithResolver(resolver)
+                .WithCompression(MessagePackCompression.Lz4BlockArray);
+
+            MessagePackSerializer.DefaultOptions = Options;
+            _initialized = true;
+        }
+    }
+}

--- a/Sources/Stockflow.Protocol/Stockflow.Protocol.csproj
+++ b/Sources/Stockflow.Protocol/Stockflow.Protocol.csproj
@@ -1,9 +1,16 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <!-- MsgPack017: init-only properties with initializers reset to default on deserialization.
+             Safe here because both peers always emit every key on the wire. -->
+        <NoWarn>$(NoWarn);MsgPack017</NoWarn>
     </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="MessagePack" Version="3.1.4" />
+    </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Chiude #9.

## Cosa cambia

Nuova libreria `Stockflow.Protocol`: wire-format MessagePack condiviso fra server e client (Unity/web/CLI/WMS). Zero dipendenze su ASP.NET o Simulation — i client referenziano solo questo progetto.

### File

- `Messages/SharedTypes.cs` — `Vector3`, enums wire-stable (`ComponentType`, `Direction`, `EntityStatus`, `SimSpeed`) e DTO embedded (`EntityState`, `ComponentState`, `SimEvent`, `MetricsSnapshot`).
- `Messages/ServerMessages.cs` — `StateDeltaMessage`, `FullStateMessage`, `CommandResultMessage` dietro `[Union]` base class.
- `Messages/ClientMessages.cs` — `PlaceComponent`, `RemoveComponent`, `ConfigureComponent`, `ChangeSpeed`, `RequestFullState` (tutti con `CommandId` per correlazione ack).
- `Serialization/MessagePackConfig.cs` — inizializzazione idempotente, `StandardResolver` + `Lz4BlockArray` compression, installa `MessagePackSerializer.DefaultOptions`.
- `README.md` — guida completa a MessagePack (`[MessagePackObject]` / `[Key]` / `[Union]`), catalogo messaggi, esempi send/receive, regole di evoluzione del wire.
- `.csproj` — pacchetto `MessagePack 3.1.4`; soppresso `MsgPack017` con nota (non si applica: ambo i peer scrivono sempre tutte le chiavi).
- Rimosso placeholder `Class1.cs`.

## Perché

Riferimento `Docs/ARCHITECTURE_StockFlow_v0.3.md` §4.2–4.4 e §7. Il canale WebSocket (10–100 Hz) richiede un formato binario compatto: MessagePack è 2–5× più piccolo di JSON e 5–10× più veloce in (de)serializzazione. L'uso di `[Key(n)]` con tag interi e `[Union]` per il polimorfismo riduce drasticamente l'overhead rispetto a nomi di campo testuali.

## Note per il reviewer

- I tag `[Key]` e `[Union]` sono **congelati** una volta rilasciati: le regole di evoluzione sono spiegate nel README §5. Nuovi campi / messaggi vanno su numeri inediti; i numeri rimossi restano riservati.
- I DTO di stato (`EntityState`, `ComponentState`, ecc.) vivono in `SharedTypes.cs` perché sono parte del wire-format dei messaggi — non è un duplicato di `Stockflow.Simulation.Entity.EntityState`, che è graph-based (componente + porta + progress). La conversione avviene nel Webserver.
- Nessun test unitario aggiunto: la libreria è composta da DTO e configurazione. I test di round-trip MessagePack arriveranno insieme al primo consumatore (Webserver handler, issue successiva della milestone F0).
- `dotnet build Stockflow.slnx` → 0 warning, 0 error.

## Test plan

- [x] `dotnet build Stockflow.slnx` pulito
- [ ] Round-trip serialize/deserialize verificato nel primo issue F0 che consuma il Protocol (WebSocket handler)

🤖 Generated with [Claude Code](https://claude.com/claude-code)