### PR TITLE
[F0] Server — Program.cs, hosting e WebSocket base (#10)

### DIFF
--- a/Sources/Stockflow.Webserver/Configuration/ServerConfig.cs
+++ b/Sources/Stockflow.Webserver/Configuration/ServerConfig.cs
@@ -1,0 +1,32 @@
+namespace Stockflow.Webserver.Configuration;
+
+/// <summary>
+/// Strongly-typed server configuration, bound from the <c>Server</c> section of
+/// <c>appsettings.json</c> (and overridden via environment variables prefixed with
+/// <c>STOCKFLOW_</c>, e.g. <c>STOCKFLOW_Server__WebSocketPort</c>).
+/// </summary>
+public sealed class ServerConfig
+{
+    public const string SectionName = "Server";
+
+    /// <summary>Port exposing the MessagePack WebSocket channel (real-time sim deltas + commands).</summary>
+    public int WebSocketPort { get; set; } = 9600;
+
+    /// <summary>Port exposing the REST/JSON channel (scenarios, metrics export, WMS integration).</summary>
+    public int RestPort { get; set; } = 9601;
+
+    /// <summary>Deployment mode — drives auth, CORS and persistence defaults downstream.</summary>
+    public ServerMode Mode { get; set; } = ServerMode.Local;
+
+    /// <summary>Simulation tick rate in Hz. The hosted service (issue #11) reads this value.</summary>
+    public int TickRate { get; set; } = 10;
+}
+
+public enum ServerMode
+{
+    /// <summary>Single-player / Steam deployment. No auth, localhost only.</summary>
+    Local,
+
+    /// <summary>On-premise / cloud B2B deployment. Auth + TLS expected upstream.</summary>
+    Enterprise,
+}

--- a/Sources/Stockflow.Webserver/Program.cs
+++ b/Sources/Stockflow.Webserver/Program.cs
@@ -1,42 +1,50 @@
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Stockflow.Protocol.Serialization;
+using Stockflow.Webserver.Configuration;
+using Stockflow.Webserver.WebSocket;
+
+MessagePackConfig.Initialize();
+
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
-builder.Services.AddOpenApi();
+builder.Services
+    .AddOptions<ServerConfig>()
+    .Bind(builder.Configuration.GetSection(ServerConfig.SectionName))
+    .ValidateDataAnnotations();
+
+var serverConfig = builder.Configuration
+    .GetSection(ServerConfig.SectionName)
+    .Get<ServerConfig>() ?? new ServerConfig();
+
+builder.WebHost.ConfigureKestrel(options =>
+{
+    // Port split per ARCHITECTURE §7.1: 9600 = real-time WebSocket, 9601 = REST/JSON.
+    // Until we route by local port explicitly, both endpoints accept every path — the
+    // separation is a deployment convention the reverse proxy or firewall enforces.
+    options.ListenAnyIP(serverConfig.WebSocketPort, listen => listen.Protocols = HttpProtocols.Http1);
+    options.ListenAnyIP(serverConfig.RestPort,      listen => listen.Protocols = HttpProtocols.Http1AndHttp2);
+});
+
+builder.Services.AddSingleton<IClientCommandQueue, ClientCommandQueue>();
+builder.Services.AddSingleton<MessageRouter>();
+builder.Services.AddSingleton<WebSocketHandler>();
 
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
+app.UseWebSockets(new WebSocketOptions
 {
-    app.MapOpenApi();
-}
+    KeepAliveInterval = TimeSpan.FromSeconds(30),
+});
 
-app.UseHttpsRedirection();
+app.Map("/ws", async (HttpContext context, WebSocketHandler handler, IHostApplicationLifetime lifetime) =>
+{
+    await handler.HandleAsync(context, lifetime.ApplicationStopping);
+});
 
-var summaries = new[]
-                {
-                    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering",
-                    "Scorching"
-                };
-
-app.MapGet("/weatherforecast", () =>
-                               {
-                                   var forecast = Enumerable.Range(1, 5)
-                                                            .Select(index =>
-                                                                        new
-                                                                            WeatherForecast(DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
-                                                                             Random.Shared.Next(-20, 55),
-                                                                             summaries[Random.Shared.Next(summaries
-                                                                                 .Length)]))
-                                                            .ToArray();
-                                   return forecast;
-                               })
-   .WithName("GetWeatherForecast");
+app.MapGet("/api/health", (WebSocketHandler handler) => Results.Ok(new
+{
+    status            = "ok",
+    connectedClients  = handler.ConnectedClientCount,
+}));
 
 app.Run();
-
-record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
-{
-    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
-}

--- a/Sources/Stockflow.Webserver/Properties/launchSettings.json
+++ b/Sources/Stockflow.Webserver/Properties/launchSettings.json
@@ -1,20 +1,10 @@
-﻿{
+{
   "$schema": "https://json.schemastore.org/launchsettings.json",
   "profiles": {
-    "http": {
+    "Stockflow.Webserver": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "http://localhost:5090",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "https": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": false,
-      "applicationUrl": "https://localhost:7236;http://localhost:5090",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/Sources/Stockflow.Webserver/README.md
+++ b/Sources/Stockflow.Webserver/README.md
@@ -1,0 +1,123 @@
+# Stockflow.Webserver
+
+ASP.NET Core host that exposes the Stockflow simulation to clients (Unity, web, CLI, WMS).
+This project is the **only** process that runs in production — everything else is either a
+library it consumes (`Stockflow.Simulation`, `Stockflow.Protocol`, `Stockflow.Persistence`)
+or a client that talks to it over the wire.
+
+This README covers the F0 scaffolding landed with issue [#10](https://github.com/mcauzzi/Stockflow/issues/10):
+hosting bootstrap, configuration, and WebSocket accept/route/session plumbing. The
+simulation tick loop (`SimulationHostedService`) and REST endpoints arrive in later issues.
+
+---
+
+## 1. Two channels, one process
+
+Per [ARCHITECTURE §7.1](../../Docs/ARCHITECTURE_StockFlow_v0.3.md), the server exposes two
+logical channels:
+
+| Channel | Port | Format | Purpose |
+|---|---|---|---|
+| WebSocket | 9600 | MessagePack (binary, LZ4) | Real-time sim deltas at 10–100 Hz, client commands |
+| REST | 9601 | JSON | Scenarios, metrics export, WMS integration, health |
+
+Both ports are bound by a single Kestrel host. The split is a deployment convention the
+reverse proxy or firewall enforces — we do not route by local port inside the app today.
+
+Defaults (see [`Configuration/ServerConfig.cs`](Configuration/ServerConfig.cs)):
+
+| Key | Default | Notes |
+|---|---|---|
+| `Server:WebSocketPort` | `9600` | Binary + LZ4 MessagePack |
+| `Server:RestPort` | `9601` | JSON |
+| `Server:Mode` | `Local` | `Local` (Steam/localhost) or `Enterprise` (Docker/B2B) |
+| `Server:TickRate` | `10` | Hz. Consumed by `SimulationHostedService` (issue #11). |
+
+Any value is overridable via environment variable, e.g.
+`STOCKFLOW_Server__WebSocketPort=9700`.
+
+---
+
+## 2. WebSocket pipeline
+
+```
+           HTTP upgrade at /ws
+                   │
+                   ▼
+         WebSocketHandler.HandleAsync
+                   │ accepts upgrade, creates session
+                   ▼
+      ┌──────── ClientSession ─────────┐
+      │   ReceiveLoop  │   SendLoop    │
+      │   (1 per sess) │   (1 per sess)│
+      └────────┬───────┴───────┬───────┘
+               │               ▲
+               ▼               │
+       MessageRouter      WebSocketHandler
+       .RouteAsync        .BroadcastAsync
+               │               ▲
+               ▼               │
+       ClientCommandQueue   SimulationHostedService (#11)
+       ─ producer ─►        ─ consumer ─►
+                                SimulationEngine.ProcessCommand
+                                SimulationEngine.Tick
+                                SimulationEngine.GetStateDelta
+```
+
+### 2.1 Receive path
+
+1. `WebSocketHandler.HandleAsync` accepts the upgrade and spins up a `ClientSession`.
+2. `ClientSession.ReceiveLoopAsync` reads binary frames until the peer closes.
+3. Each complete frame is handed to `MessageRouter.RouteAsync`.
+4. The router deserialises as `ClientMessage` via `MessagePackConfig.Options` and enqueues
+   `(session, message)` onto `IClientCommandQueue`.
+5. The simulation host service (landing in issue #11) drains the queue at the top of each
+   tick and feeds messages to `SimulationEngine.ProcessCommand`.
+
+Malformed frames are logged and dropped; they do **not** kill the session — a single bad
+packet from one client never disconnects that client or any other.
+
+### 2.2 Send path
+
+`ClientSession` owns a single-reader `Channel<ServerMessage>`. Anything that needs to send
+(tick broadcast, command ack, REST-initiated push) calls `SendAsync`; the dedicated send
+loop drains the channel one frame at a time. This is required because a `WebSocket` only
+allows one outstanding `SendAsync` at a time — without the channel, concurrent senders
+from the sim thread and a REST callback would corrupt the stream.
+
+`WebSocketHandler.BroadcastAsync` is the fan-out entry point for the sim tick: it iterates
+all live sessions and enqueues the same message on each. A slow or dead peer is logged
+and skipped; the others are not blocked.
+
+---
+
+## 3. Adding a REST endpoint
+
+REST endpoints are just minimal-API `Map*` calls in `Program.cs`. For non-trivial
+controllers, add them under `Rest/` following the same DI-first pattern as the WebSocket
+classes. The only bootstrap endpoint today is `GET /api/health`, which reports the number
+of connected clients.
+
+---
+
+## 4. Running locally
+
+```bash
+dotnet run --project Sources/Stockflow.Webserver/
+```
+
+Then:
+
+- WebSocket: `ws://localhost:9600/ws`
+- Health:    `http://localhost:9601/api/health`
+
+---
+
+## 5. Cross-reference
+
+- [ARCHITECTURE §4.1, §7, §10, §14](../../Docs/ARCHITECTURE_StockFlow_v0.3.md) — channel
+  split, protocol, tick loop, threading model.
+- [Stockflow.Protocol README](../Stockflow.Protocol/README.md) — MessagePack configuration
+  and wire evolution rules that govern every byte this server sends or receives.
+- Originating issue: [#10](https://github.com/mcauzzi/Stockflow/issues/10) — F0 server
+  hosting + WebSocket base.

--- a/Sources/Stockflow.Webserver/WebSocket/ClientCommandQueue.cs
+++ b/Sources/Stockflow.Webserver/WebSocket/ClientCommandQueue.cs
@@ -1,0 +1,38 @@
+using System.Collections.Concurrent;
+using Stockflow.Protocol.Messages;
+
+namespace Stockflow.Webserver.WebSocket;
+
+/// <summary>
+/// Producer/consumer hand-off between the WebSocket receive loops (producers) and the
+/// simulation tick loop (consumer). Architecture doc §10.1 specifies a
+/// <c>ConcurrentQueue&lt;(ClientSession, ClientMessage)&gt;</c> drained at the top of every tick
+/// — this class just formalises that contract as a DI-friendly singleton.
+/// </summary>
+public interface IClientCommandQueue
+{
+    void Enqueue(ClientSession session, ClientMessage message);
+    bool TryDequeue(out (ClientSession Session, ClientMessage Message) item);
+    int  Count { get; }
+}
+
+public sealed class ClientCommandQueue : IClientCommandQueue
+{
+    private readonly ConcurrentQueue<(ClientSession, ClientMessage)> _queue = new();
+
+    public void Enqueue(ClientSession session, ClientMessage message)
+        => _queue.Enqueue((session, message));
+
+    public bool TryDequeue(out (ClientSession Session, ClientMessage Message) item)
+    {
+        if (_queue.TryDequeue(out var tuple))
+        {
+            item = tuple;
+            return true;
+        }
+        item = default;
+        return false;
+    }
+
+    public int Count => _queue.Count;
+}

--- a/Sources/Stockflow.Webserver/WebSocket/ClientSession.cs
+++ b/Sources/Stockflow.Webserver/WebSocket/ClientSession.cs
@@ -1,0 +1,166 @@
+using System.Net.WebSockets;
+using System.Threading.Channels;
+using MessagePack;
+using Stockflow.Protocol.Messages;
+using Stockflow.Protocol.Serialization;
+
+namespace Stockflow.Webserver.WebSocket;
+
+/// <summary>
+/// One connected client. Owns the <see cref="System.Net.WebSockets.WebSocket"/>, the receive
+/// loop and a single-writer send channel. The send channel serialises outbound frames so that
+/// the simulation thread and any REST-triggered broadcast can call <see cref="SendAsync"/>
+/// concurrently without stepping on each other (a <see cref="System.Net.WebSockets.WebSocket"/>
+/// only allows one outstanding send at a time).
+/// </summary>
+public sealed class ClientSession : IAsyncDisposable
+{
+    private const int ReceiveBufferSize = 16 * 1024;
+
+    private readonly System.Net.WebSockets.WebSocket _socket;
+    private readonly Channel<ServerMessage>         _outbound;
+    private readonly ILogger<ClientSession>         _logger;
+    private readonly CancellationTokenSource        _lifetime = new();
+
+    private Task? _sendLoop;
+
+    public ClientSession(System.Net.WebSockets.WebSocket socket, ILogger<ClientSession> logger)
+    {
+        _socket   = socket;
+        _logger   = logger;
+        _outbound = Channel.CreateUnbounded<ServerMessage>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = false,
+        });
+    }
+
+    public Guid Id { get; } = Guid.NewGuid();
+
+    /// <summary>Closed when the socket has been fully drained (receive + send loops ended).</summary>
+    public CancellationToken ClosedToken => _lifetime.Token;
+
+    /// <summary>
+    /// Queue a message for delivery. Returns immediately; the dedicated send loop picks it up.
+    /// Thread-safe — any caller (sim tick, REST endpoint, handler) may invoke this.
+    /// </summary>
+    public ValueTask SendAsync(ServerMessage message, CancellationToken cancellationToken = default)
+        => _outbound.Writer.WriteAsync(message, cancellationToken);
+
+    /// <summary>
+    /// Run the receive + send loops until the socket closes or <paramref name="stoppingToken"/>
+    /// fires. Returns when both loops have exited; the socket is left in whatever state the
+    /// peer (or an exception) produced — <see cref="DisposeAsync"/> handles the final close.
+    /// </summary>
+    public async Task RunAsync(
+        Func<ClientSession, ReadOnlyMemory<byte>, ValueTask> onBinaryFrame,
+        CancellationToken stoppingToken)
+    {
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken, _lifetime.Token);
+
+        _sendLoop = Task.Run(() => SendLoopAsync(linked.Token), linked.Token);
+
+        try
+        {
+            await ReceiveLoopAsync(onBinaryFrame, linked.Token).ConfigureAwait(false);
+        }
+        finally
+        {
+            _outbound.Writer.TryComplete();
+            _lifetime.Cancel();
+            try { if (_sendLoop is not null) await _sendLoop.ConfigureAwait(false); }
+            catch (OperationCanceledException) { }
+        }
+    }
+
+    private async Task ReceiveLoopAsync(
+        Func<ClientSession, ReadOnlyMemory<byte>, ValueTask> onBinaryFrame,
+        CancellationToken cancellationToken)
+    {
+        var buffer = new byte[ReceiveBufferSize];
+        using var assembled = new MemoryStream();
+
+        while (!cancellationToken.IsCancellationRequested
+               && _socket.State == WebSocketState.Open)
+        {
+            assembled.SetLength(0);
+            WebSocketReceiveResult result;
+            do
+            {
+                result = await _socket.ReceiveAsync(buffer, cancellationToken).ConfigureAwait(false);
+
+                if (result.MessageType == WebSocketMessageType.Close)
+                {
+                    await _socket.CloseAsync(
+                        WebSocketCloseStatus.NormalClosure,
+                        "peer closed",
+                        cancellationToken).ConfigureAwait(false);
+                    return;
+                }
+
+                assembled.Write(buffer, 0, result.Count);
+            }
+            while (!result.EndOfMessage);
+
+            if (result.MessageType != WebSocketMessageType.Binary)
+            {
+                _logger.LogWarning("Session {SessionId}: ignoring non-binary frame ({Type})",
+                    Id, result.MessageType);
+                continue;
+            }
+
+            try
+            {
+                await onBinaryFrame(this, assembled.ToArray()).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Session {SessionId}: frame handler threw", Id);
+            }
+        }
+    }
+
+    private async Task SendLoopAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await foreach (var message in _outbound.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+            {
+                if (_socket.State != WebSocketState.Open) return;
+
+                var payload = MessagePackSerializer.Serialize(message, MessagePackConfig.Options, cancellationToken);
+                await _socket.SendAsync(
+                    payload,
+                    WebSocketMessageType.Binary,
+                    endOfMessage: true,
+                    cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) { /* shutdown */ }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Session {SessionId}: send loop failed", Id);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _outbound.Writer.TryComplete();
+        _lifetime.Cancel();
+
+        try
+        {
+            if (_socket.State is WebSocketState.Open or WebSocketState.CloseReceived)
+            {
+                await _socket.CloseAsync(
+                    WebSocketCloseStatus.NormalClosure,
+                    "server shutdown",
+                    CancellationToken.None).ConfigureAwait(false);
+            }
+        }
+        catch { /* socket may already be dead */ }
+
+        _socket.Dispose();
+        _lifetime.Dispose();
+    }
+}

--- a/Sources/Stockflow.Webserver/WebSocket/MessageRouter.cs
+++ b/Sources/Stockflow.Webserver/WebSocket/MessageRouter.cs
@@ -1,0 +1,49 @@
+using MessagePack;
+using Stockflow.Protocol.Messages;
+using Stockflow.Protocol.Serialization;
+
+namespace Stockflow.Webserver.WebSocket;
+
+/// <summary>
+/// Deserialises raw binary frames from a <see cref="ClientSession"/> into
+/// <see cref="ClientMessage"/> instances and hands them to the
+/// <see cref="IClientCommandQueue"/> for the simulation tick to consume. Lives on the hot
+/// path: every received frame passes through here, but all heavy lifting (command validation
+/// and state mutation) happens later on the sim thread.
+/// </summary>
+public sealed class MessageRouter
+{
+    private readonly IClientCommandQueue    _queue;
+    private readonly ILogger<MessageRouter> _logger;
+
+    public MessageRouter(IClientCommandQueue queue, ILogger<MessageRouter> logger)
+    {
+        _queue  = queue;
+        _logger = logger;
+    }
+
+    public ValueTask RouteAsync(ClientSession session, ReadOnlyMemory<byte> payload)
+    {
+        ClientMessage? message;
+        try
+        {
+            message = MessagePackSerializer.Deserialize<ClientMessage>(payload, MessagePackConfig.Options);
+        }
+        catch (MessagePackSerializationException ex)
+        {
+            _logger.LogWarning(ex,
+                "Session {SessionId}: dropping malformed frame ({Bytes} bytes)",
+                session.Id, payload.Length);
+            return ValueTask.CompletedTask;
+        }
+
+        if (message is null)
+        {
+            _logger.LogWarning("Session {SessionId}: deserialised to null, dropping", session.Id);
+            return ValueTask.CompletedTask;
+        }
+
+        _queue.Enqueue(session, message);
+        return ValueTask.CompletedTask;
+    }
+}

--- a/Sources/Stockflow.Webserver/WebSocket/WebSocketHandler.cs
+++ b/Sources/Stockflow.Webserver/WebSocket/WebSocketHandler.cs
@@ -1,0 +1,87 @@
+using System.Collections.Concurrent;
+using Stockflow.Protocol.Messages;
+
+namespace Stockflow.Webserver.WebSocket;
+
+/// <summary>
+/// Accepts WebSocket upgrade requests, owns the live set of <see cref="ClientSession"/>
+/// instances, and provides a single broadcast fan-out point for the simulation tick loop.
+/// Registered as a singleton; safe to call from any thread.
+/// </summary>
+public sealed class WebSocketHandler
+{
+    private readonly ConcurrentDictionary<Guid, ClientSession> _sessions = new();
+    private readonly ILoggerFactory                            _loggerFactory;
+    private readonly ILogger<WebSocketHandler>                 _logger;
+    private readonly MessageRouter                             _router;
+
+    public WebSocketHandler(
+        MessageRouter              router,
+        ILoggerFactory             loggerFactory,
+        ILogger<WebSocketHandler>  logger)
+    {
+        _router        = router;
+        _loggerFactory = loggerFactory;
+        _logger        = logger;
+    }
+
+    public int ConnectedClientCount => _sessions.Count;
+
+    /// <summary>
+    /// Handle an incoming WebSocket request: accept the upgrade, register a session, and
+    /// block until the connection closes. Call from an ASP.NET request delegate.
+    /// </summary>
+    public async Task HandleAsync(HttpContext context, CancellationToken applicationStopping)
+    {
+        if (!context.WebSockets.IsWebSocketRequest)
+        {
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return;
+        }
+
+        using var socket = await context.WebSockets.AcceptWebSocketAsync();
+        var session = new ClientSession(socket, _loggerFactory.CreateLogger<ClientSession>());
+
+        _sessions[session.Id] = session;
+        _logger.LogInformation(
+            "Client {SessionId} connected from {Remote} (total={Count})",
+            session.Id,
+            context.Connection.RemoteIpAddress,
+            _sessions.Count);
+
+        try
+        {
+            await session.RunAsync(_router.RouteAsync, applicationStopping).ConfigureAwait(false);
+        }
+        finally
+        {
+            _sessions.TryRemove(session.Id, out _);
+            await session.DisposeAsync().ConfigureAwait(false);
+            _logger.LogInformation(
+                "Client {SessionId} disconnected (total={Count})",
+                session.Id,
+                _sessions.Count);
+        }
+    }
+
+    /// <summary>
+    /// Fan-out a server message to every connected client. Drops sends that fail without
+    /// aborting the others — a slow or dead client must not stall the sim tick.
+    /// </summary>
+    public async ValueTask BroadcastAsync(ServerMessage message, CancellationToken cancellationToken = default)
+    {
+        foreach (var session in _sessions.Values)
+        {
+            try
+            {
+                await session.SendAsync(message, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Broadcast to session {SessionId} failed; continuing",
+                    session.Id);
+            }
+        }
+    }
+}

--- a/Sources/Stockflow.Webserver/appsettings.json
+++ b/Sources/Stockflow.Webserver/appsettings.json
@@ -5,5 +5,11 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Server": {
+    "WebSocketPort": 9600,
+    "RestPort": 9601,
+    "Mode": "Local",
+    "TickRate": 10
+  }
 }


### PR DESCRIPTION
Closes #10.

## Summary
- Bootstrap ASP.NET Core di `Stockflow.Webserver`: Kestrel su porte 9600 (WebSocket) e 9601 (REST) come da ARCHITECTURE §7.1, binding di `ServerConfig` dalla sezione `Server` di `appsettings.json`.
- Pipeline WebSocket completa: `WebSocketHandler` (accept/upgrade + registry sessioni + broadcast), `ClientSession` (receive loop + send loop serializzato via `Channel<ServerMessage>`), `MessageRouter` (deserializzazione MessagePack e accodamento), `ClientCommandQueue` (producer/consumer pronta per `SimulationHostedService` in #11).
- Endpoint `/ws` per il canale real-time e `/api/health` placeholder sul lato REST. `MessagePackConfig.Initialize()` chiamato allo startup.
- README del progetto con diagramma della pipeline e cross-ref a ARCHITECTURE §7/§10/§14.

## Test plan
- [x] `dotnet build Stockflow.slnx` pulito, 0 warning 0 errori.
- [x] `dotnet test Stockflow.slnx` verde (nessuna regressione sul motore di simulazione).
- [ ] Smoke manuale: `dotnet run --project Sources/Stockflow.Webserver/` → connessione WebSocket a `ws://localhost:9600/ws` e `GET http://localhost:9601/api/health`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)