### PR TITLE
[F0] Server — SimulationHostedService (tick loop) (#11)

### DIFF
--- a/Sources/Stockflow.Simulation/Core/SimulationClock.cs
+++ b/Sources/Stockflow.Simulation/Core/SimulationClock.cs
@@ -11,8 +11,9 @@ public class SimulationClock
     // Phase 2: enforced at 1x when external connections are active
     public bool IsLiveMode => TimeScale == 1f;
 
-    public void Advance(float realDelta)
+    // Caller already supplies a pre-scaled delta (1f/tickRate * TimeScale).
+    public void Advance(float delta)
     {
-        _simulatedTime += realDelta * TimeScale;
+        _simulatedTime += delta;
     }
 }

--- a/Sources/Stockflow.Webserver/Configuration/ServerConfig.cs
+++ b/Sources/Stockflow.Webserver/Configuration/ServerConfig.cs
@@ -18,8 +18,13 @@ public sealed class ServerConfig
     /// <summary>Deployment mode — drives auth, CORS and persistence defaults downstream.</summary>
     public ServerMode Mode { get; set; } = ServerMode.Local;
 
-    /// <summary>Simulation tick rate in Hz. The hosted service (issue #11) reads this value.</summary>
+    /// <summary>Simulation tick rate in Hz.</summary>
     public int TickRate { get; set; } = 10;
+
+    /// <summary>Grid dimensions for the simulation engine.</summary>
+    public int GridWidth  { get; set; } = 50;
+    public int GridLength { get; set; } = 50;
+    public int GridFloors { get; set; } = 1;
 }
 
 public enum ServerMode

--- a/Sources/Stockflow.Webserver/Hosting/SimulationHostedService.cs
+++ b/Sources/Stockflow.Webserver/Hosting/SimulationHostedService.cs
@@ -1,0 +1,156 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Options;
+using Stockflow.Protocol.Messages;
+using Stockflow.Simulation.Component;
+using Stockflow.Simulation.Core;
+using Stockflow.Webserver.Configuration;
+using Stockflow.Webserver.WebSocket;
+using SimEntityState   = Stockflow.Simulation.Entity.EntityState;
+using SimComponentType = Stockflow.Simulation.Component.ComponentType;
+using ProtoEntityStatus = Stockflow.Protocol.Messages.EntityStatus;
+using ProtoDirection    = Stockflow.Protocol.Messages.Direction;
+
+namespace Stockflow.Webserver.Hosting;
+
+public sealed class SimulationHostedService : BackgroundService
+{
+    // SimSpeed ordinal → TimeScale multiplier (matches SimSpeed enum order)
+    private static readonly float[] TimeScaleBySpeed = [0f, 1f, 2f, 5f, 10f, 1f];
+
+    private readonly SimulationEngine    _engine;
+    private readonly IClientCommandQueue _queue;
+    private readonly WebSocketHandler    _wsHandler;
+    private readonly int                 _tickRate;
+    private readonly ILogger<SimulationHostedService> _logger;
+    private readonly Stopwatch           _wallClock = Stopwatch.StartNew();
+
+    public SimulationHostedService(
+        SimulationEngine                  engine,
+        IClientCommandQueue               queue,
+        WebSocketHandler                  wsHandler,
+        IOptions<ServerConfig>            config,
+        ILogger<SimulationHostedService>  logger)
+    {
+        _engine    = engine;
+        _queue     = queue;
+        _wsHandler = wsHandler;
+        _tickRate  = config.Value.TickRate;
+        _logger    = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1.0 / _tickRate));
+
+        _logger.LogInformation("Simulation tick loop started at {TickRate} Hz", _tickRate);
+
+        while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false))
+        {
+            await DrainCommandQueueAsync(stoppingToken).ConfigureAwait(false);
+
+            _engine.Tick(1f / _tickRate * _engine.TimeScale);
+
+            var delta = _engine.GetStateDelta();
+            await _wsHandler.BroadcastAsync(BuildDeltaMessage(delta), stoppingToken)
+                            .ConfigureAwait(false);
+        }
+
+        _logger.LogInformation("Simulation tick loop stopped");
+    }
+
+    private async ValueTask DrainCommandQueueAsync(CancellationToken ct)
+    {
+        while (_queue.TryDequeue(out var item))
+            await HandleMessageAsync(item.Session, item.Message, ct).ConfigureAwait(false);
+    }
+
+    private async ValueTask HandleMessageAsync(ClientSession session, ClientMessage msg, CancellationToken ct)
+    {
+        switch (msg)
+        {
+            case RequestFullStateMessage:
+                await session.SendAsync(BuildFullStateMessage(), ct).ConfigureAwait(false);
+                return;
+
+            case ChangeSpeedMessage changeSpeed:
+                _engine.TimeScale = TimeScaleBySpeed[(int)changeSpeed.Speed];
+                await session.SendAsync(Ack(msg.CommandId), ct).ConfigureAwait(false);
+                return;
+
+            default:
+                // Concrete command translation is implemented in #33
+                await session.SendAsync(
+                    Nack(msg.CommandId, $"Not implemented: {msg.GetType().Name}"),
+                    ct).ConfigureAwait(false);
+                return;
+        }
+    }
+
+    private StateDeltaMessage BuildDeltaMessage(StateDelta delta)
+    {
+        var byId = _engine.State.Components.ToDictionary(c => c.Id);
+        return new StateDeltaMessage
+        {
+            ServerTime          = ServerTime,
+            SimulationTime      = delta.SimulationTime,
+            TimeScale           = _engine.TimeScale,
+            CreatedEntities     = [..delta.AddedEntityStates.Select(ToProtoEntity)],
+            UpdatedEntities     = [..delta.UpdatedEntityStates.Select(ToProtoEntity)],
+            RemovedEntityIds    = [..delta.RemovedEntityIds],
+            CreatedComponents   = [..delta.AddedComponentIds
+                .Where(byId.ContainsKey)
+                .Select(id => ToProtoComponent(byId[id]))],
+            RemovedComponentIds = [..delta.RemovedComponentIds],
+        };
+    }
+
+    private FullStateMessage BuildFullStateMessage() => new()
+    {
+        ServerTime     = ServerTime,
+        SimulationTime = _engine.SimulationTime,
+        TimeScale      = _engine.TimeScale,
+        Components     = [.._engine.State.Components.Select(ToProtoComponent)],
+        Entities       = [.._engine.State.Entities.Active.Values
+            .Select(e => ToProtoEntity(SimEntityState.From(e)))],
+    };
+
+    private CommandResultMessage Ack(int commandId) => new()
+    {
+        ServerTime = ServerTime,
+        CommandId  = commandId,
+        Success    = true,
+    };
+
+    private CommandResultMessage Nack(int commandId, string reason) => new()
+    {
+        ServerTime   = ServerTime,
+        CommandId    = commandId,
+        Success      = false,
+        ErrorMessage = reason,
+    };
+
+    private float ServerTime => (float)_wallClock.Elapsed.TotalSeconds;
+
+    private static Protocol.Messages.EntityState ToProtoEntity(SimEntityState s) => new()
+    {
+        Id       = s.Id,
+        Sku      = s.Sku,
+        Position = Vector3.Zero, // world-space interpolation: future milestone
+        Status   = (ProtoEntityStatus)(int)s.Status,
+    };
+
+    private static ComponentState ToProtoComponent(ISimComponent c) => new()
+    {
+        Id     = c.Id,
+        Kind   = KindString(c.Type),
+        GridX  = c.Position.X,
+        GridY  = c.Position.Y,
+        Facing = (ProtoDirection)(int)c.Facing,
+    };
+
+    private static string KindString(SimComponentType type) => type switch
+    {
+        SimComponentType.OneWayConveyor => ComponentKinds.OneWayConveyor,
+        _                               => type.ToString(),
+    };
+}

--- a/Sources/Stockflow.Webserver/Program.cs
+++ b/Sources/Stockflow.Webserver/Program.cs
@@ -1,6 +1,9 @@
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.Options;
 using Stockflow.Protocol.Serialization;
+using Stockflow.Simulation.Core;
 using Stockflow.Webserver.Configuration;
+using Stockflow.Webserver.Hosting;
 using Stockflow.Webserver.WebSocket;
 
 MessagePackConfig.Initialize();
@@ -28,6 +31,12 @@ builder.WebHost.ConfigureKestrel(options =>
 builder.Services.AddSingleton<IClientCommandQueue, ClientCommandQueue>();
 builder.Services.AddSingleton<MessageRouter>();
 builder.Services.AddSingleton<WebSocketHandler>();
+builder.Services.AddSingleton<SimulationEngine>(sp =>
+{
+    var cfg = sp.GetRequiredService<IOptions<ServerConfig>>().Value;
+    return new SimulationEngine(cfg.GridWidth, cfg.GridLength, cfg.GridFloors);
+});
+builder.Services.AddHostedService<SimulationHostedService>();
 
 var app = builder.Build();
 

--- a/Sources/Stockflow.Webserver/appsettings.json
+++ b/Sources/Stockflow.Webserver/appsettings.json
@@ -10,6 +10,9 @@
     "WebSocketPort": 9600,
     "RestPort": 9601,
     "Mode": "Local",
-    "TickRate": 10
+    "TickRate": 10,
+    "GridWidth": 50,
+    "GridLength": 50,
+    "GridFloors": 1
   }
 }

--- a/Sources/Stockflow.WsTestClient/Program.cs
+++ b/Sources/Stockflow.WsTestClient/Program.cs
@@ -1,0 +1,150 @@
+﻿using System.Net.WebSockets;
+using MessagePack;
+using Stockflow.Protocol.Messages;
+using Stockflow.Protocol.Serialization;
+
+MessagePackConfig.Initialize();
+
+const string DefaultUrl = "ws://localhost:9600/ws";
+var url = args.Length > 0 ? args[0] : DefaultUrl;
+
+using var ws  = new ClientWebSocket();
+using var cts = new CancellationTokenSource();
+
+Console.CancelKeyPress += (_, e) => { e.Cancel = true; cts.Cancel(); };
+
+Console.WriteLine($"Connecting to {url}...");
+try
+{
+    await ws.ConnectAsync(new Uri(url), cts.Token);
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"Connection failed: {ex.Message}");
+    return 1;
+}
+
+Console.WriteLine("Connected.\n");
+Console.WriteLine("Commands: full | speed <0-5> | quit");
+Console.WriteLine("          (0=Paused 1=Normal 2=Fast 3=Faster 4=UltraFast 5=Live)\n");
+
+int nextCommandId = 1;
+
+var receiveTask = ReceiveLoopAsync(ws, cts.Token);
+var inputTask   = InputLoopAsync(ws, cts.Token);
+
+await Task.WhenAny(receiveTask, inputTask);
+cts.Cancel();
+
+try { await Task.WhenAll(receiveTask, inputTask); }
+catch (OperationCanceledException) { }
+
+if (ws.State == WebSocketState.Open)
+    await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "bye", CancellationToken.None);
+
+Console.WriteLine("\nDisconnected.");
+return 0;
+
+// ── receive ───────────────────────────────────────────────────────────────────
+
+async Task ReceiveLoopAsync(ClientWebSocket socket, CancellationToken ct)
+{
+    var buffer = new byte[64 * 1024];
+    using var assembled = new MemoryStream();
+
+    while (!ct.IsCancellationRequested && socket.State == WebSocketState.Open)
+    {
+        assembled.SetLength(0);
+        WebSocketReceiveResult result;
+        do
+        {
+            result = await socket.ReceiveAsync(buffer, ct);
+            if (result.MessageType == WebSocketMessageType.Close) return;
+            assembled.Write(buffer, 0, result.Count);
+        }
+        while (!result.EndOfMessage);
+
+        if (result.MessageType != WebSocketMessageType.Binary) continue;
+
+        try
+        {
+            var msg = MessagePackSerializer.Deserialize<ServerMessage>(
+                assembled.ToArray(), MessagePackConfig.Options, ct);
+            PrintMessage(msg);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[ERR] Deserialize failed: {ex.Message}");
+        }
+    }
+}
+
+// ── input ─────────────────────────────────────────────────────────────────────
+
+async Task InputLoopAsync(ClientWebSocket socket, CancellationToken ct)
+{
+    while (!ct.IsCancellationRequested)
+    {
+        string? line;
+        try { line = await Task.Run(Console.ReadLine, ct); }
+        catch (OperationCanceledException) { return; }
+
+        if (line is null) return;
+
+        var parts = line.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0) continue;
+
+        if (parts[0] is "quit" or "q" or "exit") { cts.Cancel(); return; }
+
+        ClientMessage? msg = parts[0].ToLowerInvariant() switch
+        {
+            "full" => new RequestFullStateMessage { CommandId = nextCommandId++ },
+
+            "speed" when parts.Length == 2 && byte.TryParse(parts[1], out var s) && s <= 5
+                => new ChangeSpeedMessage { CommandId = nextCommandId++, Speed = (SimSpeed)s },
+
+            _ => null,
+        };
+
+        if (msg is null) { Console.WriteLine("Unknown command."); continue; }
+
+        var payload = MessagePackSerializer.Serialize(msg, MessagePackConfig.Options, ct);
+        await socket.SendAsync(payload, WebSocketMessageType.Binary, endOfMessage: true, ct);
+        Console.WriteLine($"[SENT] {msg.GetType().Name} id={msg.CommandId}");
+    }
+}
+
+// ── print ─────────────────────────────────────────────────────────────────────
+
+static void PrintMessage(ServerMessage msg)
+{
+    switch (msg)
+    {
+        case StateDeltaMessage d:
+            Console.WriteLine(
+                $"[DELTA] srv={d.ServerTime:F2}s sim={d.SimulationTime:F3}s scale={d.TimeScale}" +
+                $"  +e={d.CreatedEntities.Length} ~e={d.UpdatedEntities.Length} -e={d.RemovedEntityIds.Length}" +
+                $"  +c={d.CreatedComponents.Length} -c={d.RemovedComponentIds.Length}" +
+                (d.Events.Length > 0 ? $"  events={d.Events.Length}" : ""));
+            break;
+
+        case FullStateMessage f:
+            Console.WriteLine(
+                $"[FULL]  srv={f.ServerTime:F2}s sim={f.SimulationTime:F3}s scale={f.TimeScale}" +
+                $"  entities={f.Entities.Length}  components={f.Components.Length}");
+            foreach (var c in f.Components)
+                Console.WriteLine($"         component id={c.Id} kind={c.Kind} ({c.GridX},{c.GridY}) facing={c.Facing}");
+            foreach (var e in f.Entities)
+                Console.WriteLine($"         entity    id={e.Id} sku={e.Sku} status={e.Status}");
+            break;
+
+        case CommandResultMessage r:
+            var status = r.Success ? "OK" : $"FAIL: {r.ErrorMessage}";
+            Console.WriteLine($"[ACK]   id={r.CommandId} {status}");
+            break;
+
+        default:
+            Console.WriteLine($"[???]   {msg.GetType().Name}");
+            break;
+    }
+}

--- a/Sources/Stockflow.WsTestClient/Stockflow.WsTestClient.csproj
+++ b/Sources/Stockflow.WsTestClient/Stockflow.WsTestClient.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Stockflow.Protocol\Stockflow.Protocol.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Stockflow.slnx
+++ b/Stockflow.slnx
@@ -10,6 +10,7 @@
   </Folder>
   <Folder Name="/Tests/">
     <Project Path="./Sources/Stockflow.Tests.Simulation/Stockflow.Tests.Simulation.csproj" />
+    <Project Path="./Sources/Stockflow.WsTestClient/Stockflow.WsTestClient.csproj" />
   </Folder>
   <Folder Name="/WebServer/">
     <Project Path="./Sources/Stockflow.Webserver/Stockflow.Webserver.csproj" />


### PR DESCRIPTION
## Summary
- Aggiunge `SimulationHostedService` (`BackgroundService` con `PeriodicTimer`) in `Stockflow.Webserver/Hosting/`
- Tick loop: drena `IClientCommandQueue` → gestisce `RequestFullStateMessage` / `ChangeSpeedMessage` / fallback NACK → `engine.Tick()` → `GetStateDelta()` → `BroadcastAsync(StateDeltaMessage)`
- Gestione velocità variabile: `ChangeSpeedMessage` mappa `SimSpeed` → `TimeScale` (0x/1x/2x/5x/10x/1x)
- Fix `SimulationClock.Advance`: rimossa la moltiplicazione `* TimeScale` interna perché il caller fornisce già un delta pre-scalato (`1f/tickRate * TimeScale`), eliminando il double-scaling
- Aggiunge `GridWidth/GridLength/GridFloors` a `ServerConfig` (default 50×50×1) per creare il `SimulationEngine` via DI
- `SimulationEngine` e `SimulationHostedService` registrati in `Program.cs`

## Test plan
- [ ] `dotnet build Stockflow.slnx` — zero warning/error ✅
- [ ] `dotnet run --project Sources/Stockflow.Webserver/` si avvia e logga "Simulation tick loop started at 10 Hz"
- [ ] Connessione WebSocket a `ws://localhost:9600/ws` riceve `StateDeltaMessage` ogni ~100ms
- [ ] `RequestFullStateMessage` → `FullStateMessage` rispedita solo al mittente
- [ ] `ChangeSpeedMessage(Fast)` → `TimeScale` diventa 2, delta messages riflettono `TimeScale=2`
- [ ] Shutdown graceful: il loop termina al `CancellationToken` senza eccezioni

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)