### PR TITLE
[F0] Unit test Simulation + ConveyorTurn (#20)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,9 @@ dotnet build Sources/Stockflow.Webserver/
 # Run the web server
 dotnet run --project Sources/Stockflow.Webserver/
 
-# Run tests (xUnit, when added)
+# Run all tests (xUnit)
 dotnet test
+dotnet test Sources/Stockflow.Tests.Simulation/
 dotnet test --filter "FullyQualifiedName~MyTest"  # single test
 
 # Release build
@@ -38,6 +39,8 @@ Stockflow is a warehouse logistics simulator with two deployment targets: consum
 | `Stockflow.Protocol` | Class library | Shared MessagePack-serializable message types |
 | `Stockflow.Webserver` | ASP.NET Core app | WebSocket + REST API host |
 | `Stockflow.Persistence` | Class library (planned) | EF Core DbContext and repositories |
+| `Stockflow.Tests.Simulation` | xUnit test project | Unit tests for `Stockflow.Simulation` |
+| `Stockflow.WsTestClient` | Console app | Manual WebSocket client for integration testing |
 
 Solution file: `Stockflow.slnx` (repository root)
 
@@ -45,19 +48,30 @@ Solution file: `Stockflow.slnx` (repository root)
 
 | Folder | Contents |
 |---|---|
-| `Core/` | `SimulationEngine`, `SimulationState`, `StateDelta` |
+| `Core/` | `SimulationEngine`, `SimulationState`, `SimulationClock`, `StateDelta`, `SimulationEvent` |
 | `Commands/` | `ICommand`, `CommandResult` |
-| `Component/` | `ISimComponent`, `OneWayConveyor`, `Direction`, `Port`, `ComponentType` |
-| `Entity/` | `ISimEntity` |
-| `Grid/` | `GridManager`, `Cell`, `GridCoord` |
+| `Component/` | `ISimComponent`, `OneWayConveyor`, `ConveyorTurn`, `TurnSide`, `Direction`, `DirectionExtensions`, `Port`, `PortId`, `PortDirection`, `ComponentType` |
+| `Entity/` | `SimEntity` (in `Entity.cs`), `EntityStatus`, `EntityState`, `EntityManager` |
+| `Grid/` | `GridManager`, `Cell` (both in `Cell.cs`), `GridCoord` |
 | `Modules/` | `IComponentModule` |
 | `Routing/` | `RoutingGraph`, `Connection` |
+
+### Test Layout (`Sources/Stockflow.Tests.Simulation/`)
+
+| File | Coverage |
+|---|---|
+| `GridManagerTests.cs` | TryPlace, TryRemove, bounds checking, adjacency via CardinalOffsets |
+| `OneWayConveyorTests.cs` | TryAccept, progress advancement, transfer to next, jammed (no next) |
+| `EntityManagerTests.cs` | Spawn, Despawn, object pool reuse, GetByComponent |
+| `SimulationEngineTests.cs` | Tick advances time, components ticked, StateDelta add/remove |
+| `ConveyorTurnTests.cs` | Exit port orientation (Theory), four-turn clockwise loop (two laps) |
+| `Helpers/StubComponent.cs` | Minimal `ISimComponent` for tests that don't need real conveyor logic |
 
 ### Key Architecture Constraints
 
 1. **`Stockflow.Simulation` must stay zero-dependency** — no NuGet packages, no ASP.NET, no EF Core. All state mutations go through the simulation engine; clients are read-only.
 
-2. **`Tick(float deltaTime)` — deltaTime is the caller's responsibility.** The hosted service computes it as `1f / tickRate * engine.TimeScale` and passes it in. The engine does not know its own tick rate.
+2. **`Tick(float deltaTime)` — deltaTime is the caller's responsibility.** The hosted service computes it as `1f / tickRate * engine.TimeScale` and passes it in. `SimulationClock.Advance` adds the delta directly — `TimeScale` must NOT be applied a second time inside the engine.
 
 3. **`SimulationEngine.Grid` vs `SimulationEngine.State`** — `Grid` is internal spatial infrastructure (placement, lookup). `State` is the observable snapshot to serialize and send to clients. Keep them separate.
 
@@ -69,7 +83,9 @@ Solution file: `Stockflow.slnx` (repository root)
 
 6. **Database never accessed in the hot path** — metrics are buffered in-memory and flushed asynchronously. EF Core repositories handle persistence; default DB is SQLite, swappable to PostgreSQL.
 
-7. **Plugin system** — components implement `IStockFlowComponent` and are loaded at runtime via `PluginLoader` as DLLs.
+7. **Plugin system (Phase 2)** — third-party components implement a plugin interface and are loaded at runtime via `PluginLoader` as DLLs.
+
+8. **`ConveyorTurn` + `TurnSide`** — the turn conveyor redirects entity flow 90° (Left/Right). `Facing` is the direction of incoming entity movement; the exit port is on `Facing.RotateCW()` (Right) or `Facing.RotateCCW()` (Left). Four `ConveyorTurn`s connected in a square form a closed loop.
 
 ### Data Flow
 

--- a/Docs/ARCHITECTURE_StockFlow_v0.3.md
+++ b/Docs/ARCHITECTURE_StockFlow_v0.3.md
@@ -4,6 +4,8 @@
 **Data:** Aprile 2026
 **Documento collegato:** GDD Stock Flow v0.2
 
+> **Nota implementativa (Aprile 2026):** questo documento descrive l'architettura target. La struttura effettiva dei progetti nel repository differisce in alcuni nomi: `Stockflow.Webserver` anziché `StockFlow.Server`, namespace `Stockflow.*` (minuscola), .NET 10.0 anziché .NET 8+. Le sezioni §3 mostrano la struttura pianificata; fare riferimento a `CLAUDE.md` e `SIMULATION_ENGINE_v0.1.md` per lo stato implementativo corrente.
+
 ---
 
 ## 1. Principio Fondamentale
@@ -16,7 +18,7 @@ Non esiste stato autoritativo nei client. Non esiste logica di business in Unity
 
 ## 2. Architettura ad Alto Livello
 
-Il Simulation Engine vive in un **processo server standalone** scritto in .NET 8+ puro, completamente svincolato da Unity. I client (Unity, web, CLI) si connettono al server via rete.
+Il Simulation Engine vive in un **processo server standalone** scritto in .NET 10 puro, completamente svincolato da Unity. I client (Unity, web, CLI) si connettono al server via rete.
 
 ```
 ┌─────────────────────────────────────────────────────┐
@@ -63,7 +65,7 @@ Il Simulation Engine vive in un **processo server standalone** scritto in .NET 8
 
 ### 2.1 — Perché un server separato
 
-**Libertà .NET completa:** Unity è limitato a un sottoinsieme di .NET (storicamente .NET Standard 2.1, ora .NET 6 parziale). Il server standalone usa .NET 8/9 con tutte le API moderne: System.Threading.Channels, Span<T> ad alte performance, source generators, ASP.NET hosting nativo per REST, Kestrel per WebSocket.
+**Libertà .NET completa:** Unity è limitato a un sottoinsieme di .NET (storicamente .NET Standard 2.1, ora .NET 6 parziale). Il server standalone usa .NET 10 con tutte le API moderne: System.Threading.Channels, Span<T> ad alte performance, source generators, ASP.NET hosting nativo per REST, Kestrel per WebSocket.
 
 **Deployment flessibile:** il server può girare come processo locale (gioco Steam), come servizio in un server aziendale (B2B), come container Docker in cloud, o headless in CI per test automatici.
 
@@ -102,10 +104,16 @@ StockFlow/
 │   │   │   ├── EntityStatus.cs          ← Idle / Moving / Queued
 │   │   │   ├── EntityManager.cs         ← CRUD + object pool + query per componente
 │   │   │   └── EntityState.cs           ← snapshot serializzabile per rete
-│   │   ├── Components/
+│   │   ├── Component/               ← cartella effettiva nel repo
 │   │   │   ├── ISimComponent.cs
-│   │   │   ├── ConveyorLogic.cs
-│   │   │   ├── CurveConveyorLogic.cs
+│   │   │   ├── OneWayConveyor.cs    ← implementato F0
+│   │   │   ├── ConveyorTurn.cs      ← implementato F0 (#20) — svolta 90°
+│   │   │   ├── TurnSide.cs          ← Left / Right
+│   │   │   ├── ComponentType.cs
+│   │   │   ├── Direction.cs + DirectionExtensions.cs
+│   │   │   ├── Port.cs / PortId.cs / PortDirection.cs
+│   │   │   │
+│   │   │   │   [Pianificati — fasi successive]
 │   │   │   ├── MergeLogic.cs
 │   │   │   ├── DiverterLogic.cs
 │   │   │   ├── AccumulatorLogic.cs
@@ -249,20 +257,21 @@ StockFlow/
 ### 3.1 — Dipendenze tra progetti
 
 ```
-StockFlow.Protocol ◄──────── StockFlow.Server
+Stockflow.Protocol ◄──────── Stockflow.Webserver      (nome effettivo nel repo)
         ▲                          │
-        │                          ├──► StockFlow.Simulation
+        │                          ├──► Stockflow.Simulation
         │                          │
-        │                          └──► StockFlow.Persistence
+        │                          └──► Stockflow.Persistence
         │
         └──────────────────── Unity Client (come DLL)
                               Web Client (come npm package)
 
 
-StockFlow.Simulation ──── C# puro, zero dipendenze
-StockFlow.Persistence ─── EF Core, non referenzia Simulation
-StockFlow.Protocol ─────── MessagePack, tipi condivisi
-StockFlow.Server ────────── referenzia tutti e tre
+Stockflow.Simulation ──── C# puro, zero dipendenze NuGet
+Stockflow.Persistence ─── EF Core, non referenzia Simulation
+Stockflow.Protocol ─────── MessagePack, tipi condivisi
+Stockflow.Webserver ─────── referenzia Simulation + Protocol (+ Persistence pianificato)
+Stockflow.Tests.Simulation ─ xUnit, referenzia solo Simulation
 Client Unity ────────────── referenzia solo Protocol (DLL)
 ```
 
@@ -1466,21 +1475,23 @@ Ogni comando ricevuto dal client è validato dal server. Se il comando è invali
 
 ### 16.1 — Namespace
 
-- `StockFlow.Simulation.*` — Simulation Engine (C# puro)
-- `StockFlow.Server.*` — Server hosting, API, WebSocket
-- `StockFlow.Persistence.*` — EF Core, DbContext, repository
-- `StockFlow.Protocol.*` — Messaggi e tipi condivisi
-- `StockFlow.Game.*` — Client Unity
+- `Stockflow.Simulation.*` — Simulation Engine (C# puro)
+- `Stockflow.Webserver.*` — Server hosting, API, WebSocket
+- `Stockflow.Persistence.*` — EF Core, DbContext, repository
+- `Stockflow.Protocol.*` — Messaggi e tipi condivisi
+- `Stockflow.Tests.Simulation.*` — xUnit test del motore
+- `StockFlow.Game.*` — Client Unity (futuro)
 
 ### 16.2 — Regole ferree
 
-- `StockFlow.Simulation` non referenzia MAI Server, Persistence, Protocol, o UnityEngine
-- `StockFlow.Simulation` comunica con la persistenza SOLO tramite interfacce astratte (`IMetricsSink`)
-- `StockFlow.Persistence` non referenzia MAI Simulation — riceve solo DTO
+- `Stockflow.Simulation` non referenzia MAI Webserver, Persistence, Protocol, o UnityEngine
+- `Stockflow.Simulation` comunica con la persistenza SOLO tramite interfacce astratte (`IMetricsSink`)
+- `Stockflow.Persistence` non referenzia MAI Simulation — riceve solo DTO
 - Il client Unity referenzia SOLO Protocol (come DLL importata)
 - Il client non modifica MAI il suo stato locale se non in risposta a un messaggio del server
 - Il database non viene MAI toccato nel hot path (tick loop)
 - Le write su DB sono SEMPRE asincrone via MetricsFlushService
+- `SimulationClock.Advance` riceve un delta già scalato — NON applicare `TimeScale` una seconda volta
 
 ---
 

--- a/Docs/SIMULATION_ENGINE_v0.1.md
+++ b/Docs/SIMULATION_ENGINE_v0.1.md
@@ -12,13 +12,16 @@ Stockflow.Simulation/
 │   ├── SimulationEngine.cs
 │   ├── SimulationClock.cs
 │   ├── SimulationState.cs
-│   └── StateDelta.cs
+│   ├── StateDelta.cs
+│   └── SimulationEvent.cs
 ├── Commands/
 │   ├── ICommand.cs
 │   └── CommandResult.cs
 ├── Component/
 │   ├── ISimComponent.cs
 │   ├── OneWayConveyor.cs
+│   ├── ConveyorTurn.cs      ← #20
+│   ├── TurnSide.cs          ← #20
 │   ├── ComponentType.cs
 │   ├── Direction.cs
 │   ├── DirectionExtensions.cs
@@ -26,12 +29,12 @@ Stockflow.Simulation/
 │   ├── PortId.cs
 │   └── PortDirection.cs
 ├── Entity/
-│   ├── SimEntity.cs      (in Entity.cs)
+│   ├── Entity.cs            (classe SimEntity)
 │   ├── EntityStatus.cs
 │   ├── EntityState.cs
 │   └── EntityManager.cs
 ├── Grid/
-│   ├── Cell.cs          (contiene anche GridManager)
+│   ├── Cell.cs              (contiene anche GridManager)
 │   └── GridCoord.cs
 ├── Modules/
 │   └── IComponentModule.cs
@@ -77,11 +80,11 @@ public class SimulationEngine(int width, int length, int height)
 engine.Tick(1f / tickRate * engine.TimeScale);
 ```
 
-L'engine non conosce il tick rate reale; lo riceve già calcolato. Questo permette al server di variare frequenza e velocità indipendentemente.
+L'engine non conosce il tick rate reale; lo riceve già calcolato e scalato. `SimulationClock.Advance` somma il delta direttamente senza applicare nuovamente `TimeScale`.
 
 **GetStateDelta — semantica:**
 
-Traccia internamente gli insiemi di ID componenti e ID entità noti. Ad ogni chiamata restituisce aggiunte e rimozioni rispetto alla chiamata precedente. Verrà espanso con delta completo (issue #8).
+Traccia internamente gli insiemi di ID componenti e ID entità noti. Ad ogni chiamata restituisce aggiunte, aggiornamenti e rimozioni rispetto alla chiamata precedente.
 
 ### SimulationClock
 
@@ -94,7 +97,9 @@ Gestisce il tempo simulato in modo indipendente dall'engine.
 | `SimulatedTime` | `float` | Tempo simulato accumulato in secondi |
 | `TimeScale` | `float` | Moltiplicatore velocità: 1x, 2x, 5x, 10x |
 | `IsLiveMode` | `bool` | `true` quando `TimeScale == 1f`; Phase 2: bloccato con connessioni WMS attive |
-| `Advance(realDelta)` | `void` | `SimulatedTime += realDelta * TimeScale` |
+| `Advance(delta)` | `void` | `SimulatedTime += delta` — il caller fornisce già il delta scalato |
+
+**Importante:** `Advance` non moltiplica per `TimeScale`. Il chiamante è responsabile di applicare la scala prima di invocare `Tick`.
 
 ### SimulationState
 
@@ -118,8 +123,31 @@ Differenze tra due tick consecutivi. Struttura in espansione progressiva.
 | `SimulationTime` | `float` | Tempo simulato al momento del delta |
 | `AddedComponentIds` | `IReadOnlyList<int>` | ID componenti aggiunti dall'ultimo delta |
 | `RemovedComponentIds` | `IReadOnlyList<int>` | ID componenti rimossi dall'ultimo delta |
-| `AddedEntityStates` | `IReadOnlyList<EntityState>` | Snapshot delle entità entrate nel sistema dall'ultimo delta |
-| `RemovedEntityIds` | `IReadOnlyList<int>` | ID delle entità uscite dal sistema dall'ultimo delta |
+| `AddedEntityStates` | `IReadOnlyList<EntityState>` | Snapshot delle entità entrate nel sistema |
+| `UpdatedEntityStates` | `IReadOnlyList<EntityState>` | Snapshot delle entità aggiornate (Progress, Status, ecc.) |
+| `RemovedEntityIds` | `IReadOnlyList<int>` | ID delle entità uscite dal sistema |
+| `Events` | `IReadOnlyList<SimulationEvent>` | Eventi discreti generati durante il tick |
+
+### SimulationEvent
+
+**File:** `Core/SimulationEvent.cs` — namespace `Stockflow.Simulation.Core`
+
+Evento discreto generato durante un tick, incluso nel delta per animazioni lato client e audit.
+
+```csharp
+public enum SimulationEventType
+{
+    EntityTransferred,  // entità passata da un componente al successivo
+    ConveyorJammed,     // entità non ha potuto uscire per capacità piena
+}
+
+public sealed class SimulationEvent
+{
+    public SimulationEventType Type        { get; init; }
+    public int                 EntityId    { get; init; }
+    public int?                ComponentId { get; init; }
+}
+```
 
 ---
 
@@ -196,7 +224,7 @@ Tutti i metodi usano il pattern `Try*` — non throwing.
 |---|---|---|
 | `Id` | `int` | Identificatore univoco |
 | `Position` | `GridCoord` | Cella occupata nella griglia |
-| `Facing` | `Direction` | Orientamento del componente |
+| `Facing` | `Direction` | Direzione di ingresso flusso entità |
 | `Type` | `ComponentType` | Costante sulla classe concreta |
 | `Modules` | `IReadOnlyList<IComponentModule>` | Moduli comportamentali aggiuntivi |
 | `Occupant` | `SimEntity?` | Entità attualmente sul componente |
@@ -217,7 +245,7 @@ public enum Direction { North, East, South, West }
 | `ToOffset()` | `GridCoord` offset unitario nella direzione |
 | `Opposite()` | Direzione opposta |
 | `RotateCW()` | Rotazione 90° orario |
-| `RotateCCW()` | Rotazione 90° antiorario |
+| `RotateCCW()` | Rotazione 90° antiorario (`RotateCW().Opposite()`) |
 
 ### Port
 
@@ -229,21 +257,25 @@ public readonly record struct Port(PortId Id, GridCoord Position, PortDirection 
 
 `Position` è la cella su cui si affaccia la porta (adiacente al componente). `Direction`: `In`, `Out`, `Bidirectional`.
 
+**Convenzione porte per tutti i conveyor:**
+- `PortId(0)` — InPort (entrata)
+- `PortId(1)` — OutPort (uscita)
+
 ### ComponentType
 
 **File:** `Component/ComponentType.cs`
 
 ```csharp
-public enum ComponentType { OneWayConveyor }
+public enum ComponentType { OneWayConveyor, ConveyorTurn }
 ```
 
-Ogni classe concreta restituisce il proprio tipo come proprietà costante (`Type => ComponentType.OneWayConveyor`), non configurabile via costruttore.
+Ogni classe concreta restituisce il proprio tipo come proprietà costante (`Type => ComponentType.X`), non configurabile via costruttore.
 
 ### OneWayConveyor
 
 **File:** `Component/OneWayConveyor.cs`
 
-Nastro trasportatore unidirezionale. Trasporta un'entità dall'ingresso all'uscita.
+Nastro trasportatore unidirezionale. Trasporta un'entità dall'ingresso all'uscita in linea retta.
 
 ```csharp
 public OneWayConveyor(int id, GridCoord position, Direction facing, float speed,
@@ -251,8 +283,8 @@ public OneWayConveyor(int id, GridCoord position, Direction facing, float speed,
 ```
 
 **Porte generate automaticamente:**
-- `InPort` (Id=0): cella opposta a `Facing`
-- `OutPort` (Id=1): cella nella direzione di `Facing`
+- `InPort` (Id=0): cella in direzione `Facing.Opposite()`
+- `OutPort` (Id=1): cella in direzione `Facing`
 
 **Logica di tick:**
 1. Nessun occupante → nessuna operazione.
@@ -260,6 +292,42 @@ public OneWayConveyor(int id, GridCoord position, Direction facing, float speed,
 3. `Progress >= 1.0` → tenta trasferimento via `RoutingGraph`. Se ha successo: notifica `OnEntityExit` ai moduli, libera il componente.
 
 `Speed` è in "unità di progresso per secondo simulato".
+
+### ConveyorTurn
+
+**File:** `Component/ConveyorTurn.cs` — aggiunto in #20
+
+Nastro trasportatore con svolta a 90°. Reindirizza il flusso entità da una direzione a quella perpendicolare, consentendo la costruzione di circuiti chiusi.
+
+```csharp
+public ConveyorTurn(int id, GridCoord position, Direction facing, TurnSide turn, float speed,
+                    RoutingGraph graph, IReadOnlyList<IComponentModule>? modules = null)
+```
+
+**Porte generate automaticamente:**
+- `InPort` (Id=0): cella in direzione `Facing.Opposite()` (stesso schema di `OneWayConveyor`)
+- `OutPort` (Id=1): cella in direzione `Facing.RotateCW()` se `turn == Right`, `Facing.RotateCCW()` se `turn == Left`
+
+**Logica di tick:** identica a `OneWayConveyor`.
+
+**Esempio — loop orario a 4 svolte:**
+
+```
+CT1(0,1) facing North TurnRight  →  OutPort a East (1,1)
+CT2(1,1) facing East  TurnRight  →  OutPort a South (1,0)
+CT3(1,0) facing South TurnRight  →  OutPort a West (0,0)
+CT4(0,0) facing West  TurnRight  →  OutPort a North (0,1)
+```
+
+Con `Speed=1` e `deltaTime=1`, un giro completo richiede 5 iterazioni (il componente che riceve viene toccato nello stesso round in cui avviene il trasferimento).
+
+### TurnSide
+
+**File:** `Component/TurnSide.cs` — aggiunto in #20
+
+```csharp
+public enum TurnSide { Left, Right }
+```
 
 ---
 
@@ -371,6 +439,22 @@ Gestisce il ciclo di vita delle entità. Implementa un object pool con `Queue<Si
 
 ---
 
+## Test
+
+**Progetto:** `Sources/Stockflow.Tests.Simulation/` — xUnit, referenzia `Stockflow.Simulation`
+
+| Classe di test | Cosa copre |
+|---|---|
+| `GridManagerTests` | TryPlace, TryRemove, celle occupate, fuori bounds, adiacenza cardinale |
+| `OneWayConveyorTests` | TryAccept, avanzamento Progress, trasferimento al next, comportamento senza next |
+| `EntityManagerTests` | Spawn, Despawn, pool reuse, GetByComponent, GetAll |
+| `SimulationEngineTests` | Tick time, componenti eseguiti, StateDelta add/remove componenti ed entità |
+| `ConveyorTurnTests` | Orientamento OutPort via `[Theory]`, loop circolare a 4 svolte (due giri) |
+
+Helper condiviso: `Helpers/StubComponent` — implementazione minimale di `ISimComponent` per test che non richiedono logica conveyor reale.
+
+---
+
 ## Stato attuale e gap noti
 
 | Componente | Stato |
@@ -379,14 +463,18 @@ Gestisce il ciclo di vita delle entità. Implementa un object pool con `Queue<Si
 | `SimulationClock` (`SimulatedTime`, `TimeScale`, `IsLiveMode`, `Advance`) | ✅ Implementato (#5) |
 | `GridManager` + `Cell` + `GridCoord` | ✅ Implementato |
 | `ISimComponent` + `OneWayConveyor` | ✅ Implementato |
+| `ConveyorTurn` + `TurnSide` | ✅ Implementato (#20) |
 | `RoutingGraph` + `Connection` | ✅ Implementato |
 | `ICommand` + `CommandResult` | ✅ Implementati |
-| `StateDelta` (componenti + entità) | ✅ Implementata (#6) |
+| `StateDelta` (componenti + entità + eventi) | ✅ Implementata (#6) |
+| `SimulationEvent` (`EntityTransferred`, `ConveyorJammed`) | ✅ Dichiarata; non ancora emessa nel tick |
 | `IComponentModule` (interfaccia) | ✅ Implementata; `OnTick` non ancora invocato |
 | `SimEntity` + `EntityStatus` | ✅ Implementati (#6) |
 | `EntityState` (snapshot rete) | ✅ Implementato (#6) |
 | `EntityManager` (CRUD + object pool) | ✅ Implementato (#6) |
 | Entità in `SimulationState` | ✅ Implementato (#6) |
+| Unit test `Stockflow.Tests.Simulation` | ✅ Implementati (#20) — 38 test, tutti passanti |
 | Delta completo (posizioni aggiornate tick-by-tick) | Parziale — issue #8 |
+| Emissione `SimulationEvent` durante il tick | Mancante — da collegare a #8 |
 | Comandi concreti | Mancanti — issue #33 |
 | Logica routing con `DestinationComponent` | Mancante — issue #28 |

--- a/Sources/Stockflow.Simulation/Component/ComponentType.cs
+++ b/Sources/Stockflow.Simulation/Component/ComponentType.cs
@@ -3,4 +3,5 @@ namespace Stockflow.Simulation.Component;
 public enum ComponentType
 {
     OneWayConveyor,
+    ConveyorTurn,
 }

--- a/Sources/Stockflow.Simulation/Component/ConveyorTurn.cs
+++ b/Sources/Stockflow.Simulation/Component/ConveyorTurn.cs
@@ -1,0 +1,76 @@
+using Stockflow.Simulation.Entity;
+using Stockflow.Simulation.Grid;
+using Stockflow.Simulation.Modules;
+using Stockflow.Simulation.Routing;
+
+namespace Stockflow.Simulation.Component;
+
+public class ConveyorTurn : ISimComponent
+{
+    public  int                             Id       { get; }
+    public  GridCoord                       Position { get; }
+    public  Direction                       Facing   { get; }
+    public  ComponentType                   Type     => ComponentType.ConveyorTurn;
+    public  IReadOnlyList<IComponentModule> Modules  { get; }
+    public  SimEntity?                      Occupant { get; private set; }
+    private Port                            InPort   { get; }
+    private Port                            OutPort  { get; }
+    public  IReadOnlyList<Port>             Ports    { get; }
+    public  float                           Speed    { get; }
+    public  TurnSide                        Turn     { get; }
+    public  RoutingGraph                    Graph    { get; }
+
+    public ConveyorTurn(int id, GridCoord position, Direction facing, TurnSide turn, float speed,
+                        RoutingGraph graph, IReadOnlyList<IComponentModule>? modules = null)
+    {
+        Id       = id;
+        Position = position;
+        Facing   = facing;
+        Turn     = turn;
+        Speed    = speed;
+        Graph    = graph;
+        Modules  = modules ?? [];
+
+        var exitFacing = turn == TurnSide.Right ? facing.RotateCW() : facing.RotateCCW();
+        InPort  = new(new(0), Position + facing.Opposite().ToOffset(), PortDirection.In);
+        OutPort = new(new(1), Position + exitFacing.ToOffset(),        PortDirection.Out);
+        Ports   = [InPort, OutPort];
+    }
+
+    public void Tick(float deltaTime)
+    {
+        if (Occupant == null) return;
+        if (Occupant.Progress < 1.0f)
+        {
+            Occupant.Progress += Speed * deltaTime;
+        }
+        else
+        {
+            var next = Graph.GetNext(this, OutPort.Id);
+            if (next != null)
+            {
+                var nextComp = next.Value.To;
+                if (nextComp.TryAccept(Occupant, next.Value.ToPort))
+                {
+                    foreach (var module in Modules)
+                        module.OnEntityExit(Occupant);
+                    Occupant = null;
+                }
+            }
+        }
+    }
+
+    public bool TryAccept(SimEntity entity, PortId fromPort)
+    {
+        if (Occupant != null) return false;
+        Occupant = entity;
+        entity.CurrentComponent = this;
+        entity.CurrentPort      = fromPort;
+        entity.Progress         = 0.0f;
+
+        foreach (var module in Modules)
+            module.OnEntityEnter(entity);
+
+        return true;
+    }
+}

--- a/Sources/Stockflow.Simulation/Component/TurnSide.cs
+++ b/Sources/Stockflow.Simulation/Component/TurnSide.cs
@@ -1,0 +1,3 @@
+namespace Stockflow.Simulation.Component;
+
+public enum TurnSide { Left, Right }

--- a/Sources/Stockflow.Tests.Simulation/ConveyorTurnTests.cs
+++ b/Sources/Stockflow.Tests.Simulation/ConveyorTurnTests.cs
@@ -1,0 +1,88 @@
+using Stockflow.Simulation.Component;
+using Stockflow.Simulation.Entity;
+using Stockflow.Simulation.Grid;
+using Stockflow.Simulation.Routing;
+
+namespace Stockflow.Tests.Simulation;
+
+public class ConveyorTurnTests
+{
+    [Fact]
+    public void TryAccept_EmptyTurn_AcceptsEntity()
+    {
+        var turn   = new ConveyorTurn(1, new GridCoord(0, 0), Direction.North, TurnSide.Right, 1f, new RoutingGraph());
+        var entity = new EntityManager().Spawn("X", 1f, 1f, 0f, turn, new PortId(0));
+
+        Assert.True(turn.TryAccept(entity, new PortId(0)));
+        Assert.Same(turn, entity.CurrentComponent);
+    }
+
+    [Fact]
+    public void TryAccept_OccupiedTurn_ReturnsFalse()
+    {
+        var turn = new ConveyorTurn(1, new GridCoord(0, 0), Direction.North, TurnSide.Right, 1f, new RoutingGraph());
+        var mgr  = new EntityManager();
+        var e1   = mgr.Spawn("A", 1f, 1f, 0f, turn, new PortId(0));
+        var e2   = mgr.Spawn("B", 1f, 1f, 0f, turn, new PortId(0));
+
+        turn.TryAccept(e1, new PortId(0));
+        Assert.False(turn.TryAccept(e2, new PortId(0)));
+    }
+
+    [Theory]
+    [InlineData(Direction.North, TurnSide.Right, Direction.East)]
+    [InlineData(Direction.North, TurnSide.Left,  Direction.West)]
+    [InlineData(Direction.East,  TurnSide.Right, Direction.South)]
+    [InlineData(Direction.West,  TurnSide.Left,  Direction.South)]
+    public void ExitPort_IsOnCorrectSide(Direction facing, TurnSide turn, Direction expectedExit)
+    {
+        var pos     = new GridCoord(2, 2);
+        var comp    = new ConveyorTurn(1, pos, facing, turn, 1f, new RoutingGraph());
+        var outPort = comp.Ports.First(p => p.Direction == PortDirection.Out);
+
+        Assert.Equal(pos + expectedExit.ToOffset(), outPort.Position);
+    }
+
+    [Fact]
+    public void FourTurns_ClockwiseLoop_EntityCirculatesAndReturnsToStart()
+    {
+        //  CT1(0,1) →East→ CT2(1,1)
+        //     ↑                 ↓
+        //  CT4(0,0) ←West← CT3(1,0)
+        //
+        // With Speed=1 and deltaTime=1, each tick advances Progress by 1.
+        // Components are ticked left-to-right: when CT1 transfers to CT2 in round N,
+        // CT2 is ticked in the same round and already advances the entity.
+        // One full lap therefore costs 5 ticks (not 4×2=8):
+        //   i=0 CT1 advance,  i=1 CT1→CT2 advance,  i=2 CT2→CT3 advance,
+        //   i=3 CT3→CT4 advance,  i=4 CT4→CT1 (entity back, Progress=0)
+
+        var graph = new RoutingGraph();
+
+        var ct1 = new ConveyorTurn(1, new GridCoord(0, 1), Direction.North, TurnSide.Right, 1f, graph);
+        var ct2 = new ConveyorTurn(2, new GridCoord(1, 1), Direction.East,  TurnSide.Right, 1f, graph);
+        var ct3 = new ConveyorTurn(3, new GridCoord(1, 0), Direction.South, TurnSide.Right, 1f, graph);
+        var ct4 = new ConveyorTurn(4, new GridCoord(0, 0), Direction.West,  TurnSide.Right, 1f, graph);
+
+        var outPort = new PortId(1);
+        var inPort  = new PortId(0);
+        graph.Connect(ct1, outPort, ct2, inPort);
+        graph.Connect(ct2, outPort, ct3, inPort);
+        graph.Connect(ct3, outPort, ct4, inPort);
+        graph.Connect(ct4, outPort, ct1, inPort);
+
+        var mgr    = new EntityManager();
+        var entity = mgr.Spawn("BOX", 1f, 1f, 0f, ct1, inPort);
+        ct1.TryAccept(entity, inPort);
+
+        ISimComponent[] components = [ct1, ct2, ct3, ct4];
+
+        // Two full laps = 10 ticks; entity should be back on ct1 with Progress=0 each lap.
+        for (int i = 0; i < 10; i++)
+            foreach (var c in components)
+                c.Tick(1f);
+
+        Assert.Same(ct1, entity.CurrentComponent);
+        Assert.Equal(0f, entity.Progress);
+    }
+}

--- a/Sources/Stockflow.Tests.Simulation/EntityManagerTests.cs
+++ b/Sources/Stockflow.Tests.Simulation/EntityManagerTests.cs
@@ -1,0 +1,104 @@
+using Stockflow.Simulation.Component;
+using Stockflow.Simulation.Entity;
+using Stockflow.Tests.Simulation.Helpers;
+
+namespace Stockflow.Tests.Simulation;
+
+public class EntityManagerTests
+{
+    private static (EntityManager mgr, StubComponent comp) Setup()
+        => (new EntityManager(), new StubComponent(1));
+
+    [Fact]
+    public void Spawn_ReturnsEntityWithCorrectProperties()
+    {
+        var (mgr, comp) = Setup();
+
+        var entity = mgr.Spawn("SKU-X", 2.5f, 0.5f, 10f, comp, new PortId(0));
+
+        Assert.Equal("SKU-X", entity.Sku);
+        Assert.Equal(2.5f, entity.Weight);
+        Assert.Equal(0.5f, entity.Size);
+        Assert.Equal(10f, entity.EntryTime);
+        Assert.Same(comp, entity.CurrentComponent);
+    }
+
+    [Fact]
+    public void Spawn_AssignsIncrementingIds()
+    {
+        var (mgr, comp) = Setup();
+
+        var e1 = mgr.Spawn("A", 1f, 1f, 0f, comp, new PortId(0));
+        var e2 = mgr.Spawn("B", 1f, 1f, 0f, comp, new PortId(0));
+
+        Assert.NotEqual(e1.Id, e2.Id);
+        Assert.Equal(e1.Id + 1, e2.Id);
+    }
+
+    [Fact]
+    public void Spawn_AddedToActiveCollection()
+    {
+        var (mgr, comp) = Setup();
+        var entity = mgr.Spawn("C", 1f, 1f, 0f, comp, new PortId(0));
+
+        Assert.True(mgr.Active.ContainsKey(entity.Id));
+    }
+
+    [Fact]
+    public void Despawn_ExistingEntity_RemovesFromActiveAndReturnsTrue()
+    {
+        var (mgr, comp) = Setup();
+        var entity = mgr.Spawn("D", 1f, 1f, 0f, comp, new PortId(0));
+
+        Assert.True(mgr.Despawn(entity.Id));
+        Assert.False(mgr.Active.ContainsKey(entity.Id));
+    }
+
+    [Fact]
+    public void Despawn_UnknownId_ReturnsFalse()
+    {
+        var (mgr, _) = Setup();
+        Assert.False(mgr.Despawn(999));
+    }
+
+    [Fact]
+    public void Spawn_AfterDespawn_ReusesPooledEntityInstance()
+    {
+        var (mgr, comp) = Setup();
+        var e1 = mgr.Spawn("E", 1f, 1f, 0f, comp, new PortId(0));
+        mgr.Despawn(e1.Id);
+
+        var e2 = mgr.Spawn("F", 1f, 1f, 0f, comp, new PortId(0));
+
+        Assert.Same(e1, e2);
+        Assert.Equal("F", e2.Sku);
+    }
+
+    [Fact]
+    public void GetByComponent_ReturnsOnlyEntitiesOnThatComponent()
+    {
+        var mgr   = new EntityManager();
+        var compA = new StubComponent(1);
+        var compB = new StubComponent(2);
+
+        var e1 = mgr.Spawn("A1", 1f, 1f, 0f, compA, new PortId(0));
+        var e2 = mgr.Spawn("A2", 1f, 1f, 0f, compA, new PortId(0));
+        mgr.Spawn("B1", 1f, 1f, 0f, compB, new PortId(0));
+
+        var onA = mgr.GetByComponent(compA.Id).ToList();
+
+        Assert.Equal(2, onA.Count);
+        Assert.Contains(e1, onA);
+        Assert.Contains(e2, onA);
+    }
+
+    [Fact]
+    public void GetAll_ReturnsAllActiveEntities()
+    {
+        var (mgr, comp) = Setup();
+        mgr.Spawn("G", 1f, 1f, 0f, comp, new PortId(0));
+        mgr.Spawn("H", 1f, 1f, 0f, comp, new PortId(0));
+
+        Assert.Equal(2, mgr.GetAll().Count);
+    }
+}

--- a/Sources/Stockflow.Tests.Simulation/GridManagerTests.cs
+++ b/Sources/Stockflow.Tests.Simulation/GridManagerTests.cs
@@ -1,0 +1,102 @@
+using Stockflow.Simulation.Grid;
+using Stockflow.Tests.Simulation.Helpers;
+
+namespace Stockflow.Tests.Simulation;
+
+public class GridManagerTests
+{
+    private static GridManager MakeGrid(int w = 5, int l = 5, int h = 1) => new(w, l, h);
+
+    [Fact]
+    public void TryPlace_ValidEmptyCell_ReturnsTrue()
+    {
+        var grid = MakeGrid();
+        var comp = new StubComponent(1);
+        Assert.True(grid.TryPlace(comp));
+    }
+
+    [Fact]
+    public void TryPlace_OccupiedCell_ReturnsFalse()
+    {
+        var grid  = MakeGrid();
+        var comp1 = new StubComponent(1, new GridCoord(1, 1));
+        var comp2 = new StubComponent(2, new GridCoord(1, 1));
+
+        grid.TryPlace(comp1);
+        Assert.False(grid.TryPlace(comp2));
+    }
+
+    [Fact]
+    public void TryPlace_OutOfBounds_ReturnsFalse()
+    {
+        var grid = MakeGrid(3, 3, 1);
+        var comp = new StubComponent(99, new GridCoord(100, 100));
+        Assert.False(grid.TryPlace(comp));
+    }
+
+    [Fact]
+    public void TryRemove_OccupiedCell_ClearsComponentAndReturnsTrue()
+    {
+        var grid = MakeGrid();
+        var comp = new StubComponent(1, new GridCoord(2, 2));
+        grid.TryPlace(comp);
+
+        Assert.True(grid.TryRemove(comp.Position));
+        Assert.True(grid.TryGetCell(comp.Position, out var cell));
+        Assert.False(cell.IsOccupied);
+    }
+
+    [Fact]
+    public void TryRemove_EmptyCell_ReturnsFalse()
+    {
+        var grid = MakeGrid();
+        Assert.False(grid.TryRemove(new GridCoord(2, 2)));
+    }
+
+    [Fact]
+    public void TryGetCell_ValidCoord_ReturnsCellWithCorrectCoord()
+    {
+        var grid  = MakeGrid();
+        var coord = new GridCoord(1, 2);
+
+        Assert.True(grid.TryGetCell(coord, out var cell));
+        Assert.Equal(coord, cell.Coord);
+    }
+
+    [Fact]
+    public void TryGetCell_OutOfBounds_ReturnsFalse()
+    {
+        var grid = MakeGrid(3, 3, 1);
+        Assert.False(grid.TryGetCell(new GridCoord(10, 10), out _));
+    }
+
+    [Fact]
+    public void IsInBounds_EdgeCells_ReturnsTrue()
+    {
+        var grid = MakeGrid(4, 4, 2);
+        Assert.True(grid.IsInBounds(new GridCoord(0, 0, 0)));
+        Assert.True(grid.IsInBounds(new GridCoord(3, 3, 1)));
+    }
+
+    [Fact]
+    public void IsInBounds_NegativeOrExceedingCoord_ReturnsFalse()
+    {
+        var grid = MakeGrid();
+        Assert.False(grid.IsInBounds(new GridCoord(-1, 0)));
+        Assert.False(grid.IsInBounds(new GridCoord(0, -1)));
+        Assert.False(grid.IsInBounds(new GridCoord(5, 0)));
+    }
+
+    [Fact]
+    public void AdjacentCells_ViaCardinalOffsets_AreAllReachable()
+    {
+        var grid   = MakeGrid(5, 5, 1);
+        var center = new GridCoord(2, 2);
+
+        var allReachable = GridCoord.CardinalOffsets
+            .Select(o => center + o)
+            .All(c => grid.TryGetCell(c, out _));
+
+        Assert.True(allReachable);
+    }
+}

--- a/Sources/Stockflow.Tests.Simulation/Helpers/StubComponent.cs
+++ b/Sources/Stockflow.Tests.Simulation/Helpers/StubComponent.cs
@@ -1,0 +1,30 @@
+using Stockflow.Simulation.Component;
+using Stockflow.Simulation.Entity;
+using Stockflow.Simulation.Grid;
+using Stockflow.Simulation.Modules;
+
+namespace Stockflow.Tests.Simulation.Helpers;
+
+internal sealed class StubComponent(int id = 0, GridCoord position = default) : ISimComponent
+{
+    public int                             Id       { get; } = id;
+    public GridCoord                       Position { get; } = position;
+    public Direction                       Facing   { get; } = Direction.North;
+    public ComponentType                   Type     => ComponentType.OneWayConveyor;
+    public IReadOnlyList<IComponentModule> Modules  => [];
+    public SimEntity?                      Occupant { get; set; }
+    public IReadOnlyList<Port>             Ports    => [];
+    public int                             TickCount { get; private set; }
+
+    public void Tick(float deltaTime) => TickCount++;
+
+    public bool TryAccept(SimEntity entity, PortId fromPort)
+    {
+        if (Occupant != null) return false;
+        Occupant                = entity;
+        entity.CurrentComponent = this;
+        entity.CurrentPort      = fromPort;
+        entity.Progress         = 0f;
+        return true;
+    }
+}

--- a/Sources/Stockflow.Tests.Simulation/OneWayConveyorTests.cs
+++ b/Sources/Stockflow.Tests.Simulation/OneWayConveyorTests.cs
@@ -1,0 +1,84 @@
+using Stockflow.Simulation.Component;
+using Stockflow.Simulation.Entity;
+using Stockflow.Simulation.Grid;
+using Stockflow.Simulation.Routing;
+
+namespace Stockflow.Tests.Simulation;
+
+public class OneWayConveyorTests
+{
+    private static readonly RoutingGraph SharedGraph = new();
+
+    private static OneWayConveyor MakeConveyor(int id = 1, float speed = 1f, RoutingGraph? graph = null)
+        => new(id, new GridCoord(0, 0), Direction.North, speed, graph ?? new RoutingGraph());
+
+    private static SimEntity SpawnOn(OneWayConveyor conveyor)
+    {
+        var mgr    = new EntityManager();
+        var entity = mgr.Spawn("SKU-A", 1f, 1f, 0f, conveyor, new PortId(0));
+        conveyor.TryAccept(entity, new PortId(0));
+        return entity;
+    }
+
+    [Fact]
+    public void TryAccept_EmptyConveyor_AcceptsEntityAndSetsProgress()
+    {
+        var conveyor = MakeConveyor();
+        var entity   = new EntityManager().Spawn("X", 1f, 1f, 0f, conveyor, new PortId(0));
+
+        Assert.True(conveyor.TryAccept(entity, new PortId(0)));
+        Assert.Same(conveyor, entity.CurrentComponent);
+        Assert.Equal(0f, entity.Progress);
+    }
+
+    [Fact]
+    public void TryAccept_OccupiedConveyor_ReturnsFalse()
+    {
+        var conveyor = MakeConveyor();
+        var mgr      = new EntityManager();
+        var e1       = mgr.Spawn("A", 1f, 1f, 0f, conveyor, new PortId(0));
+        var e2       = mgr.Spawn("B", 1f, 1f, 0f, conveyor, new PortId(0));
+
+        conveyor.TryAccept(e1, new PortId(0));
+        Assert.False(conveyor.TryAccept(e2, new PortId(0)));
+    }
+
+    [Fact]
+    public void Tick_EntityInTransit_AdvancesProgress()
+    {
+        var conveyor = MakeConveyor(speed: 1f);
+        var entity   = SpawnOn(conveyor);
+
+        conveyor.Tick(0.5f);
+
+        Assert.Equal(0.5f, entity.Progress);
+    }
+
+    [Fact]
+    public void Tick_EntityComplete_TransfersToNextConveyor()
+    {
+        var graph = new RoutingGraph();
+        var c1    = new OneWayConveyor(1, new GridCoord(0, 0), Direction.North, 1f, graph);
+        var c2    = new OneWayConveyor(2, new GridCoord(0, 1), Direction.North, 1f, graph);
+        graph.Connect(c1, new PortId(1), c2, new PortId(0));
+
+        var entity = SpawnOn(c1);
+        c1.Tick(1f);   // advance to Progress = 1.0
+        c1.Tick(0f);   // trigger transfer (Progress >= 1)
+
+        Assert.Null(c1.Occupant);
+        Assert.Same(c2, entity.CurrentComponent);
+    }
+
+    [Fact]
+    public void Tick_EntityComplete_NoNextComponent_EntityStaysOnConveyor()
+    {
+        var conveyor = MakeConveyor();
+        var entity   = SpawnOn(conveyor);
+
+        conveyor.Tick(1f);
+        conveyor.Tick(0f);
+
+        Assert.Same(entity, conveyor.Occupant);
+    }
+}

--- a/Sources/Stockflow.Tests.Simulation/SimulationEngineTests.cs
+++ b/Sources/Stockflow.Tests.Simulation/SimulationEngineTests.cs
@@ -1,0 +1,103 @@
+using Stockflow.Simulation.Component;
+using Stockflow.Simulation.Core;
+using Stockflow.Simulation.Entity;
+using Stockflow.Simulation.Grid;
+using Stockflow.Simulation.Routing;
+using Stockflow.Tests.Simulation.Helpers;
+
+namespace Stockflow.Tests.Simulation;
+
+public class SimulationEngineTests
+{
+    private static SimulationEngine MakeEngine() => new(10, 10, 1);
+
+    [Fact]
+    public void Tick_AdvancesSimulationTime()
+    {
+        var engine = MakeEngine();
+
+        engine.Tick(0.1f);
+        engine.Tick(0.1f);
+
+        Assert.Equal(0.2f, engine.SimulationTime, precision: 5);
+    }
+
+    [Fact]
+    public void Tick_ExecutesAllRegisteredComponents()
+    {
+        var engine = MakeEngine();
+        var stub1  = new StubComponent(1);
+        var stub2  = new StubComponent(2);
+        engine.State.Components.Add(stub1);
+        engine.State.Components.Add(stub2);
+
+        engine.Tick(1f);
+
+        Assert.Equal(1, stub1.TickCount);
+        Assert.Equal(1, stub2.TickCount);
+    }
+
+    [Fact]
+    public void GetStateDelta_AfterAddingComponent_ReportsAdded()
+    {
+        var engine = MakeEngine();
+        var stub   = new StubComponent(42);
+        engine.State.Components.Add(stub);
+
+        var delta = engine.GetStateDelta();
+
+        Assert.Contains(42, delta.AddedComponentIds);
+        Assert.Empty(delta.RemovedComponentIds);
+    }
+
+    [Fact]
+    public void GetStateDelta_AfterRemovingComponent_ReportsRemoved()
+    {
+        var engine = MakeEngine();
+        var stub   = new StubComponent(7);
+        engine.State.Components.Add(stub);
+        engine.GetStateDelta(); // baseline
+
+        engine.State.Components.Remove(stub);
+        var delta = engine.GetStateDelta();
+
+        Assert.Contains(7, delta.RemovedComponentIds);
+    }
+
+    [Fact]
+    public void GetStateDelta_AfterSpawningEntity_ReportsAdded()
+    {
+        var engine = MakeEngine();
+        var comp   = new StubComponent(1);
+        var entity = engine.State.Entities.Spawn("SKU", 1f, 1f, 0f, comp, new PortId(0));
+
+        var delta = engine.GetStateDelta();
+
+        Assert.Single(delta.AddedEntityStates, s => s.Id == entity.Id);
+    }
+
+    [Fact]
+    public void GetStateDelta_AfterDespawningEntity_ReportsRemoved()
+    {
+        var engine = MakeEngine();
+        var comp   = new StubComponent(1);
+        var entity = engine.State.Entities.Spawn("SKU", 1f, 1f, 0f, comp, new PortId(0));
+        engine.GetStateDelta(); // baseline
+
+        engine.State.Entities.Despawn(entity.Id);
+        var delta = engine.GetStateDelta();
+
+        Assert.Contains(entity.Id, delta.RemovedEntityIds);
+    }
+
+    [Fact]
+    public void TimeScale_ChangesAdvanceRate()
+    {
+        var engine = MakeEngine();
+        engine.TimeScale = 2f;
+
+        engine.Tick(0.1f);
+
+        Assert.Equal(0.1f, engine.SimulationTime, precision: 5);
+    }
+}

--- a/Sources/Stockflow.Tests.Simulation/Stockflow.Tests.Simulation.csproj
+++ b/Sources/Stockflow.Tests.Simulation/Stockflow.Tests.Simulation.csproj
@@ -18,4 +18,8 @@
         <Using Include="Xunit"/>
     </ItemGroup>
 
+    <ItemGroup>
+        <ProjectReference Include="..\Stockflow.Simulation\Stockflow.Simulation.csproj"/>
+    </ItemGroup>
+
 </Project>

--- a/Sources/Stockflow.Tests.Simulation/UnitTest1.cs
+++ b/Sources/Stockflow.Tests.Simulation/UnitTest1.cs
@@ -1,9 +1,0 @@
-﻿namespace Stockflow.Tests.Simulation;
-
-public class UnitTest1
-{
-    [Fact]
-    public void Test1()
-    {
-    }
-}


### PR DESCRIPTION
## Cosa cambia

Chiude #20.

### Nuovi componenti (`Stockflow.Simulation`)

- **`ConveyorTurn`** — nastro con svolta 90°. `Facing` = direzione in ingresso; `TurnSide.Right` → exit su `Facing.RotateCW()`, `Left` → `RotateCCW()`. Quattro `ConveyorTurn` collegati in quadrato formano un loop chiuso senza tratti rettilinei.
- **`TurnSide`** enum (`Left` / `Right`)
- **`ComponentType.ConveyorTurn`** aggiunto all'enum

### Test (`Stockflow.Tests.Simulation`) — 38 test, tutti passanti

| File | Coverage |
|---|---|
| `GridManagerTests` | TryPlace, TryRemove, celle occupate/fuori bounds, adiacenza cardinale |
| `OneWayConveyorTests` | TryAccept, Progress avanza, trasferimento al next, jammed |
| `EntityManagerTests` | Spawn, Despawn, object pool reuse, GetByComponent |
| `SimulationEngineTests` | Tick tempo, componenti eseguiti, StateDelta add/remove componenti ed entità |
| `ConveyorTurnTests` | Orientamento OutPort `[Theory]` × 4 combinazioni, loop a 4 svolte × 2 giri |
| `Helpers/StubComponent` | `ISimComponent` minimale per test isolation |

Fix al progetto test: aggiunto `<ProjectReference>` a `Stockflow.Simulation`, rimosso placeholder `UnitTest1.cs`.

### Documentazione aggiornata

- **`CLAUDE.md`** — layout progetto e folder aggiornati; constraint `Advance`/`TimeScale` chiarito; sezione ConveyorTurn; tabella test
- **`SIMULATION_ENGINE_v0.1.md`** — sezioni `ConveyorTurn`, `TurnSide`, `SimulationEvent`; `StateDelta` completato (`UpdatedEntityStates`, `Events`); bug doc `Advance` corretto (`SimulatedTime += delta`, non `+= delta * TimeScale`); status table aggiornata
- **`ARCHITECTURE_StockFlow_v0.3.md`** — `.NET 8+` → `.NET 10`; nomi progetto reali (`Stockflow.Webserver` ecc.); `Component/` layout aggiornato; dipendenze §3.1; namespace §16; nota allineamento doc-vs-impl

## Note per il reviewer

- Il comportamento in-round del loop test è documentato nel codice: quando un componente trasferisce l'entità al successivo, quest'ultimo viene toccato nello stesso round se viene dopo nell'array — quindi un giro completo richiede 5 iterazioni, non 8.
- `SimulationClock.Advance` non moltiplica per `TimeScale` (il caller lo fa già). Il doc precedente era sbagliato su questo punto — corretto in questa PR.