### PR TITLE
feat: cancellazione componenti, velocità conveyor, multi-placement

### DIFF
--- a/Sources/Stockflow.Console/src/app/app.html
+++ b/Sources/Stockflow.Console/src/app/app.html
@@ -39,7 +39,7 @@
     (cellClick)="onCellClick($event)">
   </app-grid-canvas>
 
-  <app-inspector [selected]="selectedComp()"></app-inspector>
+  <app-inspector [selected]="liveSelected()"></app-inspector>
 </div>
 
 <!-- ORDERS -->

--- a/Sources/Stockflow.Console/src/app/app.html
+++ b/Sources/Stockflow.Console/src/app/app.html
@@ -24,7 +24,8 @@
     [selectedId]="selectedTool()?.id ?? null"
     (itemSelect)="onToolSelect($event)"
     (facingChange)="onFacingChange($event)"
-    (turnSideChange)="onTurnSideChange($event)">
+    (turnSideChange)="onTurnSideChange($event)"
+    (speedChange)="onPlaceSpeedChange($event)">
   </app-palette>
 
   <app-grid-canvas

--- a/Sources/Stockflow.Console/src/app/app.ts
+++ b/Sources/Stockflow.Console/src/app/app.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, HostListener, signal, computed, effect } from '@angular/core';
+import { Component, OnInit, HostListener, signal, computed, effect, Signal } from '@angular/core';
 import { NgIf } from '@angular/common';
 
 import { SimStateService } from './core/services/sim-state.service';
@@ -32,6 +32,11 @@ import { genSpark } from './core/mock/sim-mock';
 export class App implements OnInit {
   readonly activeTab      = signal<Tab>('OPERATE');
   readonly selectedComp   = signal<ComponentState | null>(null);
+  readonly liveSelected   = computed(() => {
+    const sel = this.selectedComp();
+    if (!sel) return null;
+    return this.sim.components().get(sel.id) ?? null;
+  });
   readonly selectedTool   = signal<PaletteItem | null>(null);
   readonly placeFacing    = signal<Direction>('North');
   readonly placeTurnSide  = signal<'Left' | 'Right'>('Right');

--- a/Sources/Stockflow.Console/src/app/app.ts
+++ b/Sources/Stockflow.Console/src/app/app.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, signal, computed, effect } from '@angular/core';
+import { Component, OnInit, HostListener, signal, computed, effect } from '@angular/core';
 import { NgIf } from '@angular/common';
 
 import { SimStateService } from './core/services/sim-state.service';
@@ -35,6 +35,7 @@ export class App implements OnInit {
   readonly selectedTool   = signal<PaletteItem | null>(null);
   readonly placeFacing    = signal<Direction>('North');
   readonly placeTurnSide  = signal<'Left' | 'Right'>('Right');
+  readonly placeSpeed     = signal(1);
   readonly paused         = signal(false);
   readonly currentSpeed   = signal<SimSpeed>(1);
 
@@ -92,13 +93,23 @@ export class App implements OnInit {
     this.placeTurnSide.set(side);
   }
 
+  onPlaceSpeedChange(speed: number): void {
+    this.placeSpeed.set(speed);
+  }
+
+  @HostListener('document:keydown.escape')
+  onEscape(): void {
+    this.selectedTool.set(null);
+  }
+
   onCellClick(cell: { x: number; y: number }): void {
     const tool = this.selectedTool();
     if (!tool) return;
-    const params = tool.kind === 'conveyor_turn'
-      ? { turn: this.placeTurnSide() }
-      : undefined;
-    this.sim.placeComponent(tool.kind, cell.x, cell.y, this.placeFacing(), params);
-    this.selectedTool.set(null);
+    const kind = tool.kind;
+    const params: Record<string, unknown> = {};
+    if (kind === 'conveyor_turn') params['turn'] = this.placeTurnSide();
+    if (kind === 'conveyor_oneway' || kind === 'conveyor_turn') params['speed'] = this.placeSpeed();
+    this.sim.placeComponent(kind, cell.x, cell.y, this.placeFacing(),
+      Object.keys(params).length ? params as any : undefined);
   }
 }

--- a/Sources/Stockflow.Console/src/app/core/services/sim-state.service.ts
+++ b/Sources/Stockflow.Console/src/app/core/services/sim-state.service.ts
@@ -92,7 +92,10 @@ export class SimStateService implements OnDestroy {
 
   configureComponent(id: number, props: Record<string, string>): void {
     this.http.put(`${REST_BASE}/api/sim/components/${id}`, props).subscribe({
-      next: () => this._appendEvent('i', 'REST', `Configured component #${id}`),
+      next: () => {
+        this._appendEvent('i', 'REST', `Configured component #${id}`);
+        setTimeout(() => this._loadInitialState(), 150);
+      },
       error: (err: any) => this._appendEvent('e', 'REST', `Configure failed: ${err.status}`),
     });
   }

--- a/Sources/Stockflow.Console/src/app/core/services/sim-state.service.ts
+++ b/Sources/Stockflow.Console/src/app/core/services/sim-state.service.ts
@@ -77,7 +77,7 @@ export class SimStateService implements OnDestroy {
 
   placeComponent(
     kind: string, gridX: number, gridY: number, facing: Direction,
-    params?: Partial<{ spawnRate: number; sku: string; weight: number; size: number; turn: string }>,
+    params?: Partial<{ spawnRate: number; sku: string; weight: number; size: number; turn: string; speed: number }>,
   ): void {
     const body = { kind, gridX, gridY, facing, ...params };
     this.http.post(`${REST_BASE}/api/sim/components`, body).subscribe({
@@ -94,6 +94,16 @@ export class SimStateService implements OnDestroy {
     this.http.put(`${REST_BASE}/api/sim/components/${id}`, props).subscribe({
       next: () => this._appendEvent('i', 'REST', `Configured component #${id}`),
       error: (err: any) => this._appendEvent('e', 'REST', `Configure failed: ${err.status}`),
+    });
+  }
+
+  removeComponent(id: number): void {
+    this.http.delete(`${REST_BASE}/api/sim/components/${id}`).subscribe({
+      next: () => {
+        this._appendEvent('i', 'REST', `Removed component #${id}`);
+        setTimeout(() => this._loadInitialState(), 150);
+      },
+      error: (err: any) => this._appendEvent('e', 'REST', `Remove failed: ${err.status}`),
     });
   }
 

--- a/Sources/Stockflow.Console/src/app/features/grid-canvas/grid-canvas.component.ts
+++ b/Sources/Stockflow.Console/src/app/features/grid-canvas/grid-canvas.component.ts
@@ -96,7 +96,7 @@ const FLOORS = [
         <rect [attr.width]="svgW" [attr.height]="svgH" fill="url(#dot28)"/>
 
         <!-- Components -->
-        <g *ngFor="let c of visibleComponents"
+        <g *ngFor="let c of visibleComponents; trackBy: trackById"
            [attr.transform]="'translate('+c.gridX*CELL+','+c.gridY*CELL+')'"
            style="cursor:pointer"
            (click)="selectComponent(c); $event.stopPropagation()">
@@ -370,6 +370,8 @@ export class GridCanvasComponent implements OnChanges {
     const x2 = CELL - 5, y = CELL / 2;
     return `${x2-5},${y-3} ${x2},${y} ${x2-5},${y+3}`;
   }
+
+  trackById(_: number, c: ComponentState): number { return c.id; }
 
   // Arrowhead pointing right at x=13, centered vertically — used for PackageExit input indicator
   arrowPtsExit(): string {

--- a/Sources/Stockflow.Console/src/app/features/grid-canvas/grid-canvas.component.ts
+++ b/Sources/Stockflow.Console/src/app/features/grid-canvas/grid-canvas.component.ts
@@ -145,15 +145,20 @@ const FLOORS = [
                     text-anchor="middle" opacity="0.8">GEN</text>
             </ng-container>
 
-            <!-- Package Exit: coral square with EXIT label -->
+            <!-- Package Exit: coral square with input-side arrow and EXIT label -->
             <ng-container *ngSwitchCase="'package_exit'">
               <rect x="1" y="1" [attr.width]="CELL-2" [attr.height]="CELL-2"
                     fill="#1e0e0e"
                     [attr.stroke]="c.id === selectedId ? '#f5a623' : '#4a1e1e'"
                     [attr.stroke-width]="c.id === selectedId ? 1.5 : 1"/>
-              <text [attr.x]="CELL/2" [attr.y]="CELL/2+3"
-                    font-size="6" fill="#f87171" font-family="JetBrains Mono,monospace"
-                    text-anchor="middle" letter-spacing="0.03em">EXIT</text>
+              <!-- Arrow enters from the input side (Facing.Opposite) toward center -->
+              <g [attr.transform]="'rotate('+facingRot(c.facing)+' '+CELL/2+' '+CELL/2+')'">
+                <line x1="3" [attr.y1]="CELL/2" x2="10" [attr.y2]="CELL/2" stroke="#f87171" stroke-width="1.2"/>
+                <polygon [attr.points]="arrowPtsExit()" fill="#f87171"/>
+              </g>
+              <text [attr.x]="CELL/2" [attr.y]="CELL-5"
+                    font-size="5" fill="#f87171" font-family="JetBrains Mono,monospace"
+                    text-anchor="middle" letter-spacing="0.03em" opacity="0.8">EXIT</text>
             </ng-container>
 
             <ng-container *ngSwitchDefault>
@@ -364,6 +369,12 @@ export class GridCanvasComponent implements OnChanges {
   arrowPts(): string {
     const x2 = CELL - 5, y = CELL / 2;
     return `${x2-5},${y-3} ${x2},${y} ${x2-5},${y+3}`;
+  }
+
+  // Arrowhead pointing right at x=13, centered vertically — used for PackageExit input indicator
+  arrowPtsExit(): string {
+    const x = 13, y = CELL / 2;
+    return `${x-4},${y-3} ${x},${y} ${x-4},${y+3}`;
   }
 
   // Quarter-circle arc: radius = CELL/2 - 4 = 10 (for CELL=28)

--- a/Sources/Stockflow.Console/src/app/features/inspector/inspector.component.ts
+++ b/Sources/Stockflow.Console/src/app/features/inspector/inspector.component.ts
@@ -117,8 +117,26 @@ const KIND_LABELS: Record<string, string> = {
           </div>
         </ng-container>
 
+        <!-- ── CONVEYORS ─────────────────────────────────── -->
+        <ng-container *ngIf="isConveyor">
+          <div class="panel-head"><span>CONFIG</span></div>
+          <div class="sec form-sec">
+            <div class="field">
+              <label class="field-lbl">Speed <span class="unit">cell/s</span></label>
+              <input class="field-input" type="number" [(ngModel)]="editSpeed"
+                     min="0.1" max="10" step="0.1"/>
+            </div>
+            <button class="save-btn" (click)="saveConveyor()">APPLY CHANGES</button>
+          </div>
+          <div class="panel-head"><span>PROPERTIES</span></div>
+          <div class="sec">
+            <div class="row"><div class="k">Grid</div><div class="v">({{ selected.gridX }}, {{ selected.gridY }})</div></div>
+            <div class="row"><div class="k">Facing</div><div class="v">{{ selected.facing }}</div></div>
+          </div>
+        </ng-container>
+
         <!-- ── OTHER COMPONENTS ──────────────────────────── -->
-        <ng-container *ngIf="!isGenerator && !isExit">
+        <ng-container *ngIf="!isGenerator && !isExit && !isConveyor">
           <div class="panel-head"><span>PROPERTIES</span></div>
           <div class="sec">
             <div class="row"><div class="k">Kind</div><div class="v">{{ selected.kind }}</div></div>
@@ -126,6 +144,11 @@ const KIND_LABELS: Record<string, string> = {
             <div class="row"><div class="k">Facing</div><div class="v">{{ selected.facing }}</div></div>
           </div>
         </ng-container>
+
+        <!-- ── DELETE ────────────────────────────────────── -->
+        <div class="sec">
+          <button class="del-btn" (click)="deleteComponent()">DELETE COMPONENT</button>
+        </div>
       </ng-container>
 
     </div>
@@ -216,6 +239,19 @@ const KIND_LABELS: Record<string, string> = {
       transition: all .12s;
     }
     .save-btn:hover { background: rgba(34,211,238,.14); }
+    .del-btn {
+      padding: 6px;
+      border: 1px solid rgba(248,113,113,.4);
+      background: rgba(248,113,113,.06);
+      color: #f87171;
+      font-family: var(--mono);
+      font-size: 9px;
+      letter-spacing: .08em;
+      cursor: pointer;
+      width: 100%;
+      transition: all .12s;
+    }
+    .del-btn:hover { background: rgba(248,113,113,.16); }
 
     /* Exit metrics */
     .metrics-sec { display: flex; flex-direction: column; gap: 6px; }
@@ -248,6 +284,7 @@ export class InspectorComponent implements OnChanges {
   editSpawnRate = 1;
   editSku = 'PKG';
   editEnabled = true;
+  editSpeed = 1;
 
   get kindLabel(): string {
     return this.selected ? (KIND_LABELS[this.selected.kind] ?? this.selected.kind.toUpperCase()) : '';
@@ -255,13 +292,19 @@ export class InspectorComponent implements OnChanges {
 
   get isGenerator(): boolean { return this.selected?.kind === 'package_generator'; }
   get isExit():      boolean { return this.selected?.kind === 'package_exit'; }
+  get isConveyor():  boolean {
+    return this.selected?.kind === 'conveyor_oneway' || this.selected?.kind === 'conveyor_turn';
+  }
 
   ngOnChanges(): void {
+    const p = this.selected?.properties ?? {};
     if (this.selected?.kind === 'package_generator') {
-      const p = this.selected.properties ?? {};
       this.editSpawnRate = parseFloat(p['spawnRate'] ?? '1');
       this.editSku       = p['sku'] ?? 'PKG';
       this.editEnabled   = (p['enabled'] ?? 'true') !== 'false';
+    }
+    if (this.isConveyor) {
+      this.editSpeed = parseFloat(p['speed'] ?? '1');
     }
   }
 
@@ -276,5 +319,15 @@ export class InspectorComponent implements OnChanges {
       sku:       this.editSku,
       enabled:   this.editEnabled ? 'true' : 'false',
     });
+  }
+
+  saveConveyor(): void {
+    if (!this.selected) return;
+    this.sim.configureComponent(this.selected.id, { speed: String(this.editSpeed) });
+  }
+
+  deleteComponent(): void {
+    if (!this.selected) return;
+    this.sim.removeComponent(this.selected.id);
   }
 }

--- a/Sources/Stockflow.Console/src/app/features/palette/palette.component.ts
+++ b/Sources/Stockflow.Console/src/app/features/palette/palette.component.ts
@@ -64,6 +64,15 @@ export interface PaletteItem {
         </div>
       </div>
 
+      <!-- Speed input (shown for conveyors) -->
+      <div class="facing" *ngIf="isConveyor">
+        <div class="facing-lbl">SPEED <span class="dim2">cell/s</span></div>
+        <input class="speed-input" type="number"
+               [value]="selectedSpeed"
+               (change)="setSpeed(+$any($event.target).value)"
+               min="0.1" max="10" step="0.1"/>
+      </div>
+
       <div class="note">
         <span class="dim2">✕ = backend not yet implemented</span>
       </div>
@@ -152,6 +161,18 @@ export interface PaletteItem {
     }
     .dbtn.on { color: var(--amber); border-color: var(--amber); background: rgba(245,166,35,.08); font-weight: 700; }
     .dbtn:hover:not(.on) { background: var(--bg-2); color: var(--text-1); }
+    .speed-input {
+      width: 100%;
+      box-sizing: border-box;
+      background: var(--bg-0);
+      border: 1px solid var(--border-bright);
+      color: var(--text-1);
+      font-family: var(--mono);
+      font-size: 10px;
+      padding: 4px 6px;
+      outline: none;
+    }
+    .speed-input:focus { border-color: var(--cyan); }
     .note {
       padding: 6px 10px;
       border-top: 1px solid var(--border);
@@ -165,11 +186,13 @@ export class PaletteComponent {
   @Output() itemSelect    = new EventEmitter<PaletteItem | null>();
   @Output() facingChange  = new EventEmitter<Direction>();
   @Output() turnSideChange = new EventEmitter<'Left' | 'Right'>();
+  @Output() speedChange   = new EventEmitter<number>();
 
   readonly lib = COMPONENT_LIBRARY;
   readonly directions: Direction[] = ['North', 'East', 'South', 'West'];
   selectedFacing: Direction = 'North';
   selectedTurnSide: 'Left' | 'Right' = 'Right';
+  selectedSpeed = 1;
 
   get selectedItem(): PaletteItem | null {
     if (!this.selectedId) return null;
@@ -182,6 +205,11 @@ export class PaletteComponent {
 
   get isConveyorTurn(): boolean {
     return this.selectedItem?.kind === 'conveyor_turn';
+  }
+
+  get isConveyor(): boolean {
+    const kind = this.selectedItem?.kind;
+    return kind === 'conveyor_oneway' || kind === 'conveyor_turn';
   }
 
   select(it: PaletteItem): void {
@@ -197,5 +225,10 @@ export class PaletteComponent {
   setTurnSide(side: 'Left' | 'Right'): void {
     this.selectedTurnSide = side;
     this.turnSideChange.emit(side);
+  }
+
+  setSpeed(value: number): void {
+    this.selectedSpeed = Math.max(0.1, Math.min(10, value));
+    this.speedChange.emit(this.selectedSpeed);
   }
 }

--- a/Sources/Stockflow.Simulation/Commands/PlaceComponentCommand.cs
+++ b/Sources/Stockflow.Simulation/Commands/PlaceComponentCommand.cs
@@ -29,3 +29,5 @@ public sealed record PlaceConveyorTurnCommand(
     TurnSide  Turn  = TurnSide.Right,
     float     Speed = 1f
 ) : ICommand;
+
+public sealed record RemoveComponentCommand(int ComponentId) : ICommand;

--- a/Sources/Stockflow.Simulation/Component/ConveyorTurn.cs
+++ b/Sources/Stockflow.Simulation/Component/ConveyorTurn.cs
@@ -16,7 +16,7 @@ public class ConveyorTurn : ISimComponent
     private Port                            InPort   { get; }
     private Port                            OutPort  { get; }
     public  IReadOnlyList<Port>             Ports    { get; }
-    public  float                           Speed    { get; }
+    public  float                           Speed    { get; set; }
     public  TurnSide                        Turn     { get; }
     public  RoutingGraph                    Graph    { get; }
 

--- a/Sources/Stockflow.Simulation/Component/OneWayConveyor.cs
+++ b/Sources/Stockflow.Simulation/Component/OneWayConveyor.cs
@@ -16,7 +16,7 @@ public class OneWayConveyor : ISimComponent
     private Port                            InPort   { get; }
     private Port                            OutPort  { get; }
     public  IReadOnlyList<Port>             Ports    { get; }
-    public  float                           Speed    { get; }
+    public  float                           Speed    { get; set; }
     public  RoutingGraph                    Graph    { get; }
 
     public OneWayConveyor(int          id,    GridCoord position, Direction facing, float speed,

--- a/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
+++ b/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
@@ -43,6 +43,7 @@ public class SimulationEngine
         PlaceOneWayConveyorCommand   cmd => PlaceOneWayConveyor(cmd),
         PlaceConveyorTurnCommand     cmd => PlaceConveyorTurn(cmd),
         ConfigureComponentCommand    cmd => ConfigureComponent(cmd),
+        RemoveComponentCommand       cmd => RemoveComponent(cmd),
         _                                => CommandResult.Fail($"Unknown command: {command.GetType().Name}"),
     };
 
@@ -105,9 +106,36 @@ public class SimulationEngine
                 gen.IsEnabled = enabled;
             return CommandResult.Ok();
         }
+        if (component is OneWayConveyor conv)
+        {
+            if (cmd.Properties.TryGetValue("speed", out var sp) && float.TryParse(sp, out var speed) && speed > 0)
+                conv.Speed = speed;
+            return CommandResult.Ok();
+        }
+        if (component is ConveyorTurn turn)
+        {
+            if (cmd.Properties.TryGetValue("speed", out var sp) && float.TryParse(sp, out var speed) && speed > 0)
+                turn.Speed = speed;
+            return CommandResult.Ok();
+        }
         return component is null
             ? CommandResult.Fail($"Component {cmd.ComponentId} not found")
             : CommandResult.Fail($"Component {cmd.ComponentId} ({component.Type}) is not configurable");
+    }
+
+    private CommandResult RemoveComponent(RemoveComponentCommand cmd)
+    {
+        var component = State.Components.Find(c => c.Id == cmd.ComponentId);
+        if (component is null)
+            return CommandResult.Fail($"Component {cmd.ComponentId} not found");
+
+        foreach (var entity in State.Entities.GetByComponent(cmd.ComponentId).ToList())
+            State.Entities.Despawn(entity.Id);
+
+        Graph.DisconnectAll(component);
+        Grid.TryRemove(component.Position);
+        State.Components.Remove(component);
+        return CommandResult.Ok();
     }
 
     // When a component is placed, auto-wire it to any adjacent compatible ports.

--- a/Sources/Stockflow.Simulation/Routing/RoutingGraph.cs
+++ b/Sources/Stockflow.Simulation/Routing/RoutingGraph.cs
@@ -17,6 +17,16 @@ public class RoutingGraph
         connections.Remove((component, port));
     }
 
+    public void DisconnectAll(ISimComponent component)
+    {
+        var keys = connections
+            .Where(kv => kv.Key.Item1 == component || kv.Value.To == component)
+            .Select(kv => kv.Key)
+            .ToList();
+        foreach (var key in keys)
+            connections.Remove(key);
+    }
+
     // Dato un componente e la sua porta di uscita, chi c'è dall'altra parte?
     public Connection? GetNext(ISimComponent component, PortId outPort)
     {

--- a/Sources/Stockflow.Webserver/Controllers/SimulationController.cs
+++ b/Sources/Stockflow.Webserver/Controllers/SimulationController.cs
@@ -127,9 +127,10 @@ public sealed class SimulationController(
                 req.Weight    ?? 1f,
                 req.Size      ?? 1f),
             "package_exit"    => new PlacePackageExitCommand(pos, dir),
-            "conveyor_oneway" => new PlaceOneWayConveyorCommand(pos, dir,0.1f),
+            "conveyor_oneway" => new PlaceOneWayConveyorCommand(pos, dir, req.Speed ?? 1f),
             "conveyor_turn"   => new PlaceConveyorTurnCommand(pos, dir,
-                req.Turn == "Left" ? TurnSide.Left : TurnSide.Right),
+                req.Turn == "Left" ? TurnSide.Left : TurnSide.Right,
+                req.Speed ?? 1f),
             _ => null,
         };
 
@@ -173,12 +174,10 @@ public sealed class SimulationController(
     [HttpDelete("components/{id:int}")]
     public IActionResult RemoveComponent(int id)
     {
-        logger.LogWarning("DELETE /api/sim/components/{Id} → 501 not yet implemented", id);
-        return StatusCode(StatusCodes.Status501NotImplemented, new
-        {
-            success      = false,
-            errorMessage = $"RemoveComponent({id}) not yet implemented.",
-        });
+        queue.Enqueue(new RemoveComponentCommand(id));
+
+        logger.LogInformation("DELETE /api/sim/components/{Id} → enqueued remove", id);
+        return Accepted();
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -221,7 +220,13 @@ public sealed class SimulationController(
         if (c is ConveyorTurn turn)
             return new()
             {
-                ["turn"] = turn.Turn == TurnSide.Right ? "right" : "left",
+                ["turn"]  = turn.Turn == TurnSide.Right ? "right" : "left",
+                ["speed"] = turn.Speed.ToString("F3"),
+            };
+        if (c is OneWayConveyor conv)
+            return new()
+            {
+                ["speed"] = conv.Speed.ToString("F3"),
             };
         return null;
     }
@@ -238,4 +243,5 @@ public sealed record PlaceComponentRequest(
     string? Sku       = null,
     float?  Weight    = null,
     float?  Size      = null,
-    string? Turn      = null);
+    string? Turn      = null,
+    float?  Speed     = null);

--- a/Sources/Stockflow.Webserver/Hosting/SimulationHostedService.cs
+++ b/Sources/Stockflow.Webserver/Hosting/SimulationHostedService.cs
@@ -239,7 +239,13 @@ public sealed class SimulationHostedService : BackgroundService
         if (c is ConveyorTurn turn)
             return new()
             {
-                ["turn"] = turn.Turn == TurnSide.Right ? "right" : "left",
+                ["turn"]  = turn.Turn == TurnSide.Right ? "right" : "left",
+                ["speed"] = turn.Speed.ToString("F3"),
+            };
+        if (c is OneWayConveyor conv)
+            return new()
+            {
+                ["speed"] = conv.Speed.ToString("F3"),
             };
         return null;
     }


### PR DESCRIPTION
## Summary

- **Cancellazione componenti**: `RemoveComponentCommand` + `RoutingGraph.DisconnectAll` — rimuove il componente dalla griglia, disconnette tutte le connessioni in/out dal grafo di routing, despawna le entità presenti; endpoint `DELETE /api/sim/components/{id}` ora funzionante (era 501); pulsante DELETE nell'Inspector
- **Velocità conveyor**: `Speed` settabile su `OneWayConveyor` e `ConveyorTurn`; `ConfigureComponent` gestisce la proprietà `speed`; serializzata nei delta WS e nella risposta REST; default corretto da `0.1f` a `1f` (1 cell/s); input speed nella Palette (pre-placement) e campo editabile nell'Inspector (post-placement)
- **Multi-placement**: il tool resta attivo dopo ogni click; `ESC` per deselezionare
- **PackageExit**: freccia rossa sul lato di ingresso, ruotata col facing (stesso pattern del PackageGenerator)

## Test plan

- [x] Piazzare un conveyor, verificare che il pannello Inspector mostri il campo Speed con il valore corretto
- [x] Modificare la speed via Inspector e verificare che le entità accelerino/rallentino
- [x] Piazzare più conveyor in sequenza senza dover riselezionare il tool dalla palette; ESC per uscire
- [x] Impostare la speed nella palette prima del placement e verificare che il conveyor venga creato con quella velocità
- [x] Cancellare un componente con entità sopra e verificare che spariscano entità e componente
- [x] Cancellare un conveyor nel mezzo di una catena e verificare che i vicini non si blocchino
- [x] Verificare che PackageExit mostri la freccia rossa sul lato corretto al variare del facing

🤖 Generated with [Claude Code](https://claude.com/claude-code)