### PR TITLE
refactor: ComponentSerializer + SpeedTable + placement registry

### DIFF
--- a/Sources/Stockflow.Protocol/Messages/SharedTypes.cs
+++ b/Sources/Stockflow.Protocol/Messages/SharedTypes.cs
@@ -29,6 +29,7 @@ public readonly struct Vector3
 public static class ComponentKinds
 {
     public const string OneWayConveyor   = "conveyor_oneway";
+    public const string ConveyorTurn     = "conveyor_turn";
     public const string PackageGenerator = "package_generator";
     public const string PackageExit      = "package_exit";
 }

--- a/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
+++ b/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
@@ -8,6 +8,7 @@ namespace Stockflow.Simulation.Core;
 
 public class SimulationEngine
 {
+    private readonly Dictionary<Type, Func<ICommand, int, ISimComponent>> _placementFactories;
     private HashSet<int>                 _knownComponentIds = new();
     private HashSet<int>                 _knownEntityIds    = new();
     private Dictionary<int, EntityState> _lastEntityStates  = new();
@@ -19,6 +20,32 @@ public class SimulationEngine
         Grid  = new GridManager(width, length, height);
         Graph = new RoutingGraph();
         State = new();
+
+        _placementFactories = new()
+        {
+            [typeof(PlaceOneWayConveyorCommand)] = (c, id) =>
+            {
+                var x = (PlaceOneWayConveyorCommand)c;
+                return new OneWayConveyor(id, x.Position, x.Facing, x.Speed, Graph);
+            },
+            [typeof(PlaceConveyorTurnCommand)] = (c, id) =>
+            {
+                var x = (PlaceConveyorTurnCommand)c;
+                return new ConveyorTurn(id, x.Position, x.Facing, x.Turn, x.Speed, Graph);
+            },
+            [typeof(PlacePackageGeneratorCommand)] = (c, id) =>
+            {
+                var x = (PlacePackageGeneratorCommand)c;
+                return new PackageGenerator(id, x.Position, x.Facing,
+                                            x.SpawnRate, x.Sku, x.Weight, x.Size,
+                                            Graph, State.Entities);
+            },
+            [typeof(PlacePackageExitCommand)] = (c, id) =>
+            {
+                var x = (PlacePackageExitCommand)c;
+                return new PackageExit(id, x.Position, x.Facing, State.Entities);
+            },
+        };
     }
 
     public SimulationClock Clock          { get; }
@@ -36,56 +63,26 @@ public class SimulationEngine
             component.Tick(deltaTime);
     }
 
-    public CommandResult ProcessCommand(ICommand command) => command switch
+    public CommandResult ProcessCommand(ICommand command)
     {
-        PlacePackageGeneratorCommand cmd => PlacePackageGenerator(cmd),
-        PlacePackageExitCommand      cmd => PlacePackageExit(cmd),
-        PlaceOneWayConveyorCommand   cmd => PlaceOneWayConveyor(cmd),
-        PlaceConveyorTurnCommand     cmd => PlaceConveyorTurn(cmd),
-        ConfigureComponentCommand    cmd => ConfigureComponent(cmd),
-        RemoveComponentCommand       cmd => RemoveComponent(cmd),
-        _                                => CommandResult.Fail($"Unknown command: {command.GetType().Name}"),
-    };
+        if (_placementFactories.TryGetValue(command.GetType(), out var factory))
+            return PlaceComponent(command, factory);
 
-    private CommandResult PlaceOneWayConveyor(PlaceOneWayConveyorCommand cmd)
-    {
-        var conv = new OneWayConveyor(_nextComponentId++, cmd.Position, cmd.Facing, cmd.Speed, Graph);
-        if (!Grid.TryPlace(conv))
-            return CommandResult.Fail($"Cell {cmd.Position} is occupied or out of bounds");
-        State.Components.Add(conv);
-        AutoConnect(conv);
-        return CommandResult.Ok();
+        return command switch
+        {
+            ConfigureComponentCommand cmd => ConfigureComponent(cmd),
+            RemoveComponentCommand    cmd => RemoveComponent(cmd),
+            _                              => CommandResult.Fail($"Unknown command: {command.GetType().Name}"),
+        };
     }
 
-    private CommandResult PlaceConveyorTurn(PlaceConveyorTurnCommand cmd)
+    private CommandResult PlaceComponent(ICommand cmd, Func<ICommand, int, ISimComponent> factory)
     {
-        var turn = new ConveyorTurn(_nextComponentId++, cmd.Position, cmd.Facing, cmd.Turn, cmd.Speed, Graph);
-        if (!Grid.TryPlace(turn))
-            return CommandResult.Fail($"Cell {cmd.Position} is occupied or out of bounds");
-        State.Components.Add(turn);
-        AutoConnect(turn);
-        return CommandResult.Ok();
-    }
-
-    private CommandResult PlacePackageGenerator(PlacePackageGeneratorCommand cmd)
-    {
-        var gen = new PackageGenerator(_nextComponentId++, cmd.Position, cmd.Facing,
-                                       cmd.SpawnRate, cmd.Sku, cmd.Weight, cmd.Size,
-                                       Graph, State.Entities);
-        if (!Grid.TryPlace(gen))
-            return CommandResult.Fail($"Cell {cmd.Position} is occupied or out of bounds");
-        State.Components.Add(gen);
-        AutoConnect(gen);
-        return CommandResult.Ok();
-    }
-
-    private CommandResult PlacePackageExit(PlacePackageExitCommand cmd)
-    {
-        var exit = new PackageExit(_nextComponentId++, cmd.Position, cmd.Facing, State.Entities);
-        if (!Grid.TryPlace(exit))
-            return CommandResult.Fail($"Cell {cmd.Position} is occupied or out of bounds");
-        State.Components.Add(exit);
-        AutoConnect(exit);
+        var component = factory(cmd, _nextComponentId++);
+        if (!Grid.TryPlace(component))
+            return CommandResult.Fail($"Cell {component.Position} is occupied or out of bounds");
+        State.Components.Add(component);
+        AutoConnect(component);
         return CommandResult.Ok();
     }
 

--- a/Sources/Stockflow.Webserver/Configuration/SpeedTable.cs
+++ b/Sources/Stockflow.Webserver/Configuration/SpeedTable.cs
@@ -1,0 +1,16 @@
+namespace Stockflow.Webserver.Configuration;
+
+/// <summary>
+/// Maps the wire-level <see cref="Stockflow.Protocol.Messages.SimSpeed"/> ordinal
+/// (also reused as plain int by the REST endpoint) to the engine's TimeScale multiplier.
+/// Single source of truth shared by REST and WebSocket entry points.
+/// </summary>
+public static class SpeedTable
+{
+    private static readonly float[] TimeScaleBySpeed = [0f, 1f, 2f, 5f, 10f, 1f];
+
+    public const int MinSpeed = 0;
+    public const int MaxSpeed = 5;
+
+    public static float TimeScaleFor(int speed) => TimeScaleBySpeed[speed];
+}

--- a/Sources/Stockflow.Webserver/Controllers/SimulationController.cs
+++ b/Sources/Stockflow.Webserver/Controllers/SimulationController.cs
@@ -4,9 +4,9 @@ using Stockflow.Simulation.Commands;
 using Stockflow.Simulation.Component;
 using Stockflow.Simulation.Core;
 using Stockflow.Simulation.Grid;
+using Stockflow.Webserver.Configuration;
 using Stockflow.Webserver.Queue;
-using SimComponentType = Stockflow.Simulation.Component.ComponentType;
-using ISimComponent    = Stockflow.Simulation.Component.ISimComponent;
+using Stockflow.Webserver.Serialization;
 using SimDirection     = Stockflow.Simulation.Component.Direction;
 
 namespace Stockflow.Webserver.Controllers;
@@ -28,9 +28,6 @@ public sealed class SimulationController(
     IRestCommandQueue             queue,
     ILogger<SimulationController> logger) : ControllerBase
 {
-    // Mirrors SimulationHostedService.TimeScaleBySpeed — keep in sync until extracted to shared config.
-    private static readonly float[] TimeScaleBySpeed = [0f, 1f, 2f, 5f, 10f, 1f];
-
     // ── GET /api/sim/state ────────────────────────────────────────────────────
     [HttpGet("state")]
     public IActionResult GetState()
@@ -52,12 +49,12 @@ public sealed class SimulationController(
             components     = components.Select(c => new
             {
                 id         = c.Id,
-                kind       = KindString(c.Type),
+                kind       = ComponentSerializer.KindString(c.Type),
                 gridX      = c.Position.X,
                 gridY      = c.Position.Y,
                 facing     = c.Facing.ToString(),
                 occupant   = c.Occupant?.Id,
-                properties = BuildProperties(c),
+                properties = ComponentSerializer.BuildProperties(c),
             }),
             entities = entities.Values.Select(e => new
             {
@@ -96,14 +93,14 @@ public sealed class SimulationController(
     [HttpPost("speed")]
     public IActionResult ChangeSpeed([FromBody] ChangeSpeedRequest req)
     {
-        if (req.Speed is < 0 or > 5)
+        if (req.Speed < SpeedTable.MinSpeed || req.Speed > SpeedTable.MaxSpeed)
         {
             logger.LogWarning("POST /api/sim/speed → 400 invalid speed={Speed}", req.Speed);
-            return BadRequest(new { success = false, errorMessage = "speed must be 0‥5" });
+            return BadRequest(new { success = false, errorMessage = $"speed must be {SpeedTable.MinSpeed}‥{SpeedTable.MaxSpeed}" });
         }
 
         var previous = engine.TimeScale;
-        engine.TimeScale = TimeScaleBySpeed[req.Speed];
+        engine.TimeScale = SpeedTable.TimeScaleFor(req.Speed);
 
         logger.LogInformation(
             "POST /api/sim/speed → speed={Speed} timeScale={Previous}→{TimeScale}",
@@ -121,14 +118,14 @@ public sealed class SimulationController(
 
         ICommand? cmd = req.Kind switch
         {
-            "package_generator" => new PlacePackageGeneratorCommand(pos, dir,
+            ComponentKinds.PackageGenerator => new PlacePackageGeneratorCommand(pos, dir,
                 req.SpawnRate ?? 1f,
                 req.Sku       ?? "PKG",
                 req.Weight    ?? 1f,
                 req.Size      ?? 1f),
-            "package_exit"    => new PlacePackageExitCommand(pos, dir),
-            "conveyor_oneway" => new PlaceOneWayConveyorCommand(pos, dir, req.Speed ?? 1f),
-            "conveyor_turn"   => new PlaceConveyorTurnCommand(pos, dir,
+            ComponentKinds.PackageExit    => new PlacePackageExitCommand(pos, dir),
+            ComponentKinds.OneWayConveyor => new PlaceOneWayConveyorCommand(pos, dir, req.Speed ?? 1f),
+            ComponentKinds.ConveyorTurn   => new PlaceConveyorTurnCommand(pos, dir,
                 req.Turn == "Left" ? TurnSide.Left : TurnSide.Right,
                 req.Speed ?? 1f),
             _ => null,
@@ -189,47 +186,6 @@ public sealed class SimulationController(
         "West"  => SimDirection.West,
         _       => SimDirection.North,
     };
-
-    private static string KindString(SimComponentType type) => type switch
-    {
-        SimComponentType.OneWayConveyor   => ComponentKinds.OneWayConveyor,
-        SimComponentType.ConveyorTurn     => "conveyor_turn",
-        SimComponentType.PackageGenerator => "package_generator",
-        SimComponentType.PackageExit      => "package_exit",
-        _                                 => type.ToString().ToLowerInvariant(),
-    };
-
-    private static Dictionary<string, string>? BuildProperties(ISimComponent c)
-    {
-        if (c is PackageGenerator gen)
-            return new()
-            {
-                ["spawnRate"] = gen.SpawnRate.ToString("F3"),
-                ["sku"]       = gen.Sku,
-                ["weight"]    = gen.Weight.ToString("F3"),
-                ["size"]      = gen.Size.ToString("F3"),
-                ["enabled"]   = gen.IsEnabled ? "true" : "false",
-            };
-        if (c is PackageExit exit)
-            return new()
-            {
-                ["totalProcessed"]     = exit.TotalProcessed.ToString(),
-                ["throughput"]         = exit.Throughput.ToString("F3"),
-                ["avgFulfillmentTime"] = exit.AvgFulfillmentTime.ToString("F3"),
-            };
-        if (c is ConveyorTurn turn)
-            return new()
-            {
-                ["turn"]  = turn.Turn == TurnSide.Right ? "right" : "left",
-                ["speed"] = turn.Speed.ToString("F3"),
-            };
-        if (c is OneWayConveyor conv)
-            return new()
-            {
-                ["speed"] = conv.Speed.ToString("F3"),
-            };
-        return null;
-    }
 }
 
 public sealed record ChangeSpeedRequest(int Speed);

--- a/Sources/Stockflow.Webserver/Hosting/SimulationHostedService.cs
+++ b/Sources/Stockflow.Webserver/Hosting/SimulationHostedService.cs
@@ -7,6 +7,7 @@ using Stockflow.Simulation.Core;
 using Stockflow.Simulation.Grid;
 using Stockflow.Webserver.Configuration;
 using Stockflow.Webserver.Queue;
+using Stockflow.Webserver.Serialization;
 using Stockflow.Webserver.WebSocket;
 using SimEntityState    = Stockflow.Simulation.Entity.EntityState;
 using SimComponentType  = Stockflow.Simulation.Component.ComponentType;
@@ -18,9 +19,6 @@ namespace Stockflow.Webserver.Hosting;
 
 public sealed class SimulationHostedService : BackgroundService
 {
-    // SimSpeed ordinal → TimeScale multiplier (matches SimSpeed enum order)
-    private static readonly float[] TimeScaleBySpeed = [0f, 1f, 2f, 5f, 10f, 1f];
-
     private readonly SimulationEngine    _engine;
     private readonly IClientCommandQueue _queue;
     private readonly IRestCommandQueue   _restQueue;
@@ -87,7 +85,7 @@ public sealed class SimulationHostedService : BackgroundService
                 return;
 
             case ChangeSpeedMessage changeSpeed:
-                _engine.TimeScale = TimeScaleBySpeed[(int)changeSpeed.Speed];
+                _engine.TimeScale = SpeedTable.TimeScaleFor((int)changeSpeed.Speed);
                 await session.SendAsync(Ack(msg.CommandId), ct).ConfigureAwait(false);
                 return;
 
@@ -211,51 +209,10 @@ public sealed class SimulationHostedService : BackgroundService
     private static ComponentState ToProtoComponent(ISimComponent c) => new()
     {
         Id         = c.Id,
-        Kind       = KindString(c.Type),
+        Kind       = ComponentSerializer.KindString(c.Type),
         GridX      = c.Position.X,
         GridY      = c.Position.Y,
         Facing     = (ProtoDirection)(int)c.Facing,
-        Properties = BuildProperties(c),
-    };
-
-    private static Dictionary<string, string>? BuildProperties(ISimComponent c)
-    {
-        if (c is PackageGenerator gen)
-            return new()
-            {
-                ["spawnRate"] = gen.SpawnRate.ToString("F3"),
-                ["sku"]       = gen.Sku,
-                ["weight"]    = gen.Weight.ToString("F3"),
-                ["size"]      = gen.Size.ToString("F3"),
-                ["enabled"]   = gen.IsEnabled ? "true" : "false",
-            };
-        if (c is PackageExit exit)
-            return new()
-            {
-                ["totalProcessed"]     = exit.TotalProcessed.ToString(),
-                ["throughput"]         = exit.Throughput.ToString("F3"),
-                ["avgFulfillmentTime"] = exit.AvgFulfillmentTime.ToString("F3"),
-            };
-        if (c is ConveyorTurn turn)
-            return new()
-            {
-                ["turn"]  = turn.Turn == TurnSide.Right ? "right" : "left",
-                ["speed"] = turn.Speed.ToString("F3"),
-            };
-        if (c is OneWayConveyor conv)
-            return new()
-            {
-                ["speed"] = conv.Speed.ToString("F3"),
-            };
-        return null;
-    }
-
-    private static string KindString(SimComponentType type) => type switch
-    {
-        SimComponentType.OneWayConveyor   => ComponentKinds.OneWayConveyor,
-        SimComponentType.ConveyorTurn     => "conveyor_turn",
-        SimComponentType.PackageGenerator => ComponentKinds.PackageGenerator,
-        SimComponentType.PackageExit      => ComponentKinds.PackageExit,
-        _                                 => type.ToString(),
+        Properties = ComponentSerializer.BuildProperties(c),
     };
 }

--- a/Sources/Stockflow.Webserver/Serialization/ComponentSerializer.cs
+++ b/Sources/Stockflow.Webserver/Serialization/ComponentSerializer.cs
@@ -1,0 +1,50 @@
+using Stockflow.Protocol.Messages;
+using Stockflow.Simulation.Component;
+using SimComponentType = Stockflow.Simulation.Component.ComponentType;
+using ISimComponent    = Stockflow.Simulation.Component.ISimComponent;
+
+namespace Stockflow.Webserver.Serialization;
+
+/// <summary>
+/// Single source of truth for translating a simulation component into the wire format
+/// used by both the WebSocket delta stream and the REST state endpoint.
+/// </summary>
+public static class ComponentSerializer
+{
+    public static string KindString(SimComponentType type) => type switch
+    {
+        SimComponentType.OneWayConveyor   => ComponentKinds.OneWayConveyor,
+        SimComponentType.ConveyorTurn     => ComponentKinds.ConveyorTurn,
+        SimComponentType.PackageGenerator => ComponentKinds.PackageGenerator,
+        SimComponentType.PackageExit      => ComponentKinds.PackageExit,
+        _                                 => type.ToString().ToLowerInvariant(),
+    };
+
+    public static Dictionary<string, string>? BuildProperties(ISimComponent c) => c switch
+    {
+        PackageGenerator gen => new()
+        {
+            ["spawnRate"] = gen.SpawnRate.ToString("F3"),
+            ["sku"]       = gen.Sku,
+            ["weight"]    = gen.Weight.ToString("F3"),
+            ["size"]      = gen.Size.ToString("F3"),
+            ["enabled"]   = gen.IsEnabled ? "true" : "false",
+        },
+        PackageExit exit => new()
+        {
+            ["totalProcessed"]     = exit.TotalProcessed.ToString(),
+            ["throughput"]         = exit.Throughput.ToString("F3"),
+            ["avgFulfillmentTime"] = exit.AvgFulfillmentTime.ToString("F3"),
+        },
+        ConveyorTurn turn => new()
+        {
+            ["turn"]  = turn.Turn == TurnSide.Right ? "right" : "left",
+            ["speed"] = turn.Speed.ToString("F3"),
+        },
+        OneWayConveyor conv => new()
+        {
+            ["speed"] = conv.Speed.ToString("F3"),
+        },
+        _ => null,
+    };
+}


### PR DESCRIPTION
## Summary
- Estrae `ComponentSerializer` (Webserver/Serialization) come unica sorgente per `KindString` e `BuildProperties`, eliminando la duplicazione tra `SimulationController` e `SimulationHostedService`.
- Estrae `SpeedTable` (Webserver/Configuration) per la mappa `SimSpeed → TimeScale` (idem, prima duplicata con commento `keep in sync until extracted to shared config`).
- Aggiunge `ComponentKinds.ConveyorTurn` in `Protocol/Messages/SharedTypes.cs` (era hard-coded come letterale `"conveyor_turn"` in entrambi i file).
- `SimulationEngine`: i quattro `Place*` privati sostituiti da un dispatch table `Dictionary<Type, Func<ICommand, int, ISimComponent>>` popolato nel ctor + un singolo `PlaceComponent` generico. Aggiungere un nuovo tipo di componente ora richiede solo una entry nel dizionario.

Net diff: **-23 righe**, ma soprattutto rimuove tre punti di duplicazione e prepara il terreno per il sistema plugin di Phase 2.

## Test plan
- [x] `dotnet build Stockflow.slnx` → 0 warning, 0 error
- [x] `dotnet test` → 69/69 passano
- [x] Smoke test manuale: avviare il webserver, piazzare ogni tipo di componente da Angular console, verificare che kind/properties arrivino corretti via WS e REST.