### PR TITLE
fix: posizione entity centrata in cella nei delta WebSocket

### DIFF
--- a/Sources/Stockflow.Webserver/Hosting/SimulationHostedService.cs
+++ b/Sources/Stockflow.Webserver/Hosting/SimulationHostedService.cs
@@ -192,11 +192,14 @@ public sealed class SimulationHostedService : BackgroundService
         Vector3 pos = Vector3.Zero;
         if (byId.TryGetValue(s.CurrentComponentId, out var comp))
         {
-            // Interpolate 2D grid position: entity moves from cell entry to exit along facing direction.
+            // Interpolated cell-space position of the entity centre.
+            // Convention: cell (X,Y) spans [X, X+1) × [Y, Y+1); the centre is (X+0.5, Y+0.5).
+            // Progress 0 = entity at the entry edge (opposite to facing), 1 = exit edge.
+            // pos = cellCentre + facingOffset * (progress - 0.5).
             var off = comp.Facing.ToOffset();
             pos = new Vector3(
-                comp.Position.X + off.X * s.Progress,
-                comp.Position.Y + off.Y * s.Progress,
+                comp.Position.X + 0.5f + off.X * (s.Progress - 0.5f),
+                comp.Position.Y + 0.5f + off.Y * (s.Progress - 0.5f),
                 0f);
         }
         return new()


### PR DESCRIPTION
## Summary
- `SimulationHostedService.ToProtoEntity` calcolava la posizione interpolata partendo dall'angolo top-left della cella (`comp.Position`) invece che dal centro `(X+0.5, Y+0.5)`. Il rect 6×6 lato client risultava disallineato di mezza cella su entrambi gli assi.
- Sui conveyor orizzontali (East/West) l'errore era poco visibile — entità sul bordo top della cella. Sui verticali (North/South) le entità finivano visibilmente fuori dalla colonna del conveyor.
- Nuova formula: `pos = cellCentre + facingOffset * (progress - 0.5)`. A progress=0 l'entità tocca il bordo d'ingresso, a 0.5 è al centro cella, a 1 il bordo d'uscita — sempre dentro la cella, sempre in corsia.
- Il REST `GET /api/sim/state` non è interessato: espone `progress` + `componentId` grezzi, non posizioni interpolate.

## Repro
Piazzare un `PackageGenerator` + colonna verticale di `OneWayConveyor` con facing North e un `PackageExit` in cima. Le entità arancioni 6×6 nel canvas erano disallineate a sinistra della colonna, anziché scorrere lungo di essa.

## Test plan
- [x] `dotnet build Stockflow.slnx` → 0 warning, 0 error
- [x] `dotnet test` → 69/69 passano
- [x] Smoke test manuale Angular: catena verticale e orizzontale di conveyor, verificare entità centrate e in scorrimento lungo la corsia