### PR TITLE
feat: REST scenarios + sessions API e UI Angular (issue #36)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ riderModule.iml
 /_ReSharper.Caches/
 /.idea/
 /.claude/worktrees
+
+# Scenario JSON files written at runtime live next to the .cs DTOs in this
+# folder; only the source code is tracked.
+/Sources/Stockflow.Webserver/Scenarios/*.json

--- a/Sources/Stockflow.Console/package-lock.json
+++ b/Sources/Stockflow.Console/package-lock.json
@@ -2453,9 +2453,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2473,9 +2470,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2493,9 +2487,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2513,9 +2504,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2533,9 +2521,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2553,9 +2538,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2573,9 +2555,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3019,9 +2998,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3043,9 +3019,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3067,9 +3040,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3091,9 +3061,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3115,9 +3082,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3139,9 +3103,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3319,9 +3280,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3339,9 +3297,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3359,9 +3314,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3379,9 +3331,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3558,9 +3507,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3575,9 +3521,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3592,9 +3535,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3609,9 +3549,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3626,9 +3563,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3643,9 +3577,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3660,9 +3591,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3677,9 +3605,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3694,9 +3619,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3711,9 +3633,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3728,9 +3647,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3745,9 +3661,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3762,9 +3675,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/Sources/Stockflow.Console/src/app/app.html
+++ b/Sources/Stockflow.Console/src/app/app.html
@@ -2,8 +2,14 @@
   [activeTab]="activeTab()"
   [connected]="sim.connected()"
   [restOnline]="sim.restOnline()"
-  (tabChange)="onTabChange($event)">
+  (tabChange)="onTabChange($event)"
+  (openScenarios)="scenariosOpen.set(true)">
 </app-topbar>
+
+<app-scenarios-panel
+  *ngIf="scenariosOpen()"
+  (close)="scenariosOpen.set(false)">
+</app-scenarios-panel>
 
 <app-kpi-strip
   [simClock]="sim.simClock()"

--- a/Sources/Stockflow.Console/src/app/app.ts
+++ b/Sources/Stockflow.Console/src/app/app.ts
@@ -13,6 +13,7 @@ import { EventLogComponent } from './features/event-log/event-log.component';
 import { OrdersViewComponent } from './features/orders-view/orders-view.component';
 import { MetricsViewComponent } from './features/metrics-view/metrics-view.component';
 import { StubViewComponent } from './features/stub-view/stub-view.component';
+import { ScenariosPanelComponent } from './features/scenarios-panel/scenarios-panel.component';
 import { ComponentState } from './core/models/protocol';
 import { genSpark } from './core/mock/sim-mock';
 
@@ -25,13 +26,15 @@ import { genSpark } from './core/mock/sim-mock';
     PaletteComponent, GridCanvasComponent, InspectorComponent,
     EventLogComponent,
     OrdersViewComponent, MetricsViewComponent, StubViewComponent,
+    ScenariosPanelComponent,
   ],
   templateUrl: './app.html',
   styleUrl: './app.scss',
 })
 export class App implements OnInit {
-  readonly activeTab      = signal<Tab>('OPERATE');
-  readonly selectedComp   = signal<ComponentState | null>(null);
+  readonly activeTab       = signal<Tab>('OPERATE');
+  readonly scenariosOpen   = signal(false);
+  readonly selectedComp    = signal<ComponentState | null>(null);
   readonly liveSelected   = computed(() => {
     const sel = this.selectedComp();
     if (!sel) return null;

--- a/Sources/Stockflow.Console/src/app/core/config.ts
+++ b/Sources/Stockflow.Console/src/app/core/config.ts
@@ -1,0 +1,7 @@
+/**
+ * Endpoint del server di sviluppo. Quando passeremo a un proxy.conf.json
+ * o a una build environment-aware, sostituire questo file (o derivarlo
+ * da Angular environment).
+ */
+export const REST_BASE = 'http://localhost:9601';
+export const WS_URL    = 'ws://localhost:9600/ws';

--- a/Sources/Stockflow.Console/src/app/core/models/scenario.ts
+++ b/Sources/Stockflow.Console/src/app/core/models/scenario.ts
@@ -1,0 +1,65 @@
+/**
+ * Mirror dei record C# Stockflow.Webserver.Scenarios.* (formato §6.1
+ * di ARCHITECTURE_StockFlow_v0.3). I campi non ancora supportati dalla
+ * simulazione sono opzionali pass-through.
+ */
+
+export interface ScenarioSummary {
+  id: string;
+  name: string;
+  description?: string | null;
+}
+
+export interface Scenario {
+  id: string;
+  name: string;
+  description?: string | null;
+  gridSize?: GridSize | null;
+  budget?: number | null;
+  availableComponents?: string[] | null;
+  preplacedComponents?: PreplacedComponent[] | null;
+  skuCatalog?: SkuCatalog | null;
+  orderProfile?: OrderProfile | null;
+  objectives?: Record<string, Objective> | null;
+  duration?: number | null;
+}
+
+export interface GridSize {
+  width: number;
+  height: number;
+}
+
+export interface PreplacedComponent {
+  type: string;
+  position: number[]; // [x, y]
+  direction: string;
+}
+
+export interface SkuCatalog {
+  count: number;
+  classes: Record<string, SkuClass>;
+}
+
+export interface SkuClass {
+  percentage: number;
+  accessFrequency: string;
+}
+
+export interface OrderProfile {
+  baseRate: number;
+  peakRate: number;
+  peakStartTime: number;
+  peakDuration: number;
+  linesPerOrder?: LinesPerOrder | null;
+  deadline: number;
+}
+
+export interface LinesPerOrder {
+  min: number;
+  max: number;
+}
+
+export interface Objective {
+  type: string;
+  value?: number | null;
+}

--- a/Sources/Stockflow.Console/src/app/core/models/session.ts
+++ b/Sources/Stockflow.Console/src/app/core/models/session.ts
@@ -1,0 +1,10 @@
+export type SessionStatus = 'Running' | 'Terminated';
+
+export interface SessionInfo {
+  id: string;
+  status: SessionStatus;
+  startedAt: string;     // ISO timestamp
+  endedAt?: string | null;
+  scenarioId?: string | null;
+  simulationTime: number;
+}

--- a/Sources/Stockflow.Console/src/app/core/services/scenarios.service.spec.ts
+++ b/Sources/Stockflow.Console/src/app/core/services/scenarios.service.spec.ts
@@ -1,0 +1,91 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+
+import { ScenariosService } from './scenarios.service';
+import { Scenario, ScenarioSummary } from '../models/scenario';
+import { REST_BASE } from '../config';
+
+describe('ScenariosService', () => {
+  let service: ScenariosService;
+  let http: HttpTestingController;
+  const base = `${REST_BASE}/api/scenarios`;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(ScenariosService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => http.verify());
+
+  it('list() GETs /api/scenarios and returns summaries', () => {
+    const stub: ScenarioSummary[] = [{ id: 's1', name: 'One', description: 'a' }];
+    let received: ScenarioSummary[] | undefined;
+
+    service.list().subscribe(r => (received = r));
+
+    const req = http.expectOne(base);
+    expect(req.request.method).toBe('GET');
+    req.flush(stub);
+
+    expect(received).toEqual(stub);
+  });
+
+  it('get() encodes id and GETs /api/scenarios/:id', () => {
+    const stub: Scenario = { id: 'abc.def', name: 'X' };
+
+    service.get('abc.def').subscribe();
+
+    const req = http.expectOne(`${base}/abc.def`);
+    expect(req.request.method).toBe('GET');
+    req.flush(stub);
+  });
+
+  it('create() POSTs the scenario as body', () => {
+    const s: Scenario = { id: 's1', name: 'New', description: 'hi' };
+
+    service.create(s).subscribe();
+
+    const req = http.expectOne(base);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(s);
+    req.flush(s);
+  });
+
+  it('update() PUTs to /api/scenarios/:id with body', () => {
+    const s: Scenario = { id: 's1', name: 'Updated' };
+
+    service.update(s).subscribe();
+
+    const req = http.expectOne(`${base}/s1`);
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toEqual(s);
+    req.flush(s);
+  });
+
+  it('delete() DELETEs /api/scenarios/:id', () => {
+    service.delete('s1').subscribe();
+
+    const req = http.expectOne(`${base}/s1`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush(null, { status: 204, statusText: 'No Content' });
+  });
+
+  it('propagates 404 errors to subscribers', () => {
+    let status: number | undefined;
+
+    service.get('missing').subscribe({
+      next:  () => {},
+      error: err => (status = err.status),
+    });
+
+    http.expectOne(`${base}/missing`).flush(
+      { errorMessage: 'not found' },
+      { status: 404, statusText: 'Not Found' });
+
+    expect(status).toBe(404);
+  });
+});

--- a/Sources/Stockflow.Console/src/app/core/services/scenarios.service.ts
+++ b/Sources/Stockflow.Console/src/app/core/services/scenarios.service.ts
@@ -1,0 +1,32 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+import { REST_BASE } from '../config';
+import { Scenario, ScenarioSummary } from '../models/scenario';
+
+@Injectable({ providedIn: 'root' })
+export class ScenariosService {
+  private http = inject(HttpClient);
+  private base = `${REST_BASE}/api/scenarios`;
+
+  list(): Observable<ScenarioSummary[]> {
+    return this.http.get<ScenarioSummary[]>(this.base);
+  }
+
+  get(id: string): Observable<Scenario> {
+    return this.http.get<Scenario>(`${this.base}/${encodeURIComponent(id)}`);
+  }
+
+  create(scenario: Scenario): Observable<Scenario> {
+    return this.http.post<Scenario>(this.base, scenario);
+  }
+
+  update(scenario: Scenario): Observable<Scenario> {
+    return this.http.put<Scenario>(`${this.base}/${encodeURIComponent(scenario.id)}`, scenario);
+  }
+
+  delete(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.base}/${encodeURIComponent(id)}`);
+  }
+}

--- a/Sources/Stockflow.Console/src/app/core/services/sessions.service.spec.ts
+++ b/Sources/Stockflow.Console/src/app/core/services/sessions.service.spec.ts
@@ -1,0 +1,95 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+
+import { SessionsService } from './sessions.service';
+import { SessionInfo } from '../models/session';
+import { REST_BASE } from '../config';
+
+const RUNNING: SessionInfo = {
+  id: '11111111-2222-3333-4444-555555555555',
+  status: 'Running',
+  startedAt: '2026-04-28T12:00:00Z',
+  endedAt: null,
+  scenarioId: null,
+  simulationTime: 0,
+};
+
+describe('SessionsService', () => {
+  let service: SessionsService;
+  let http: HttpTestingController;
+  const base = `${REST_BASE}/api/sessions`;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(SessionsService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => http.verify());
+
+  it('start() POSTs and updates currentSession on success', () => {
+    expect(service.currentSession()).toBeNull();
+
+    service.start().subscribe();
+
+    const req = http.expectOne(base);
+    expect(req.request.method).toBe('POST');
+    req.flush(RUNNING);
+
+    expect(service.currentSession()).toEqual(RUNNING);
+  });
+
+  it('refresh() GETs /api/sessions/:id and updates currentSession', () => {
+    service.refresh(RUNNING.id).subscribe();
+
+    const req = http.expectOne(`${base}/${RUNNING.id}`);
+    expect(req.request.method).toBe('GET');
+    req.flush(RUNNING);
+
+    expect(service.currentSession()).toEqual(RUNNING);
+  });
+
+  it('terminate() DELETEs /api/sessions/:id and clears currentSession', () => {
+    // simulate previous start
+    service.start().subscribe();
+    http.expectOne(base).flush(RUNNING);
+    expect(service.currentSession()).toEqual(RUNNING);
+
+    service.terminate(RUNNING.id).subscribe();
+    http.expectOne(`${base}/${RUNNING.id}`).flush(null, { status: 204, statusText: 'No Content' });
+
+    expect(service.currentSession()).toBeNull();
+  });
+
+  it('loadScenario() POSTs to /scenario/load with scenarioId body', () => {
+    const updated: SessionInfo = { ...RUNNING, scenarioId: 'smoke', simulationTime: 0.1 };
+
+    service.loadScenario(RUNNING.id, 'smoke').subscribe();
+
+    const req = http.expectOne(`${base}/${RUNNING.id}/scenario/load`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ scenarioId: 'smoke' });
+    req.flush(updated);
+
+    expect(service.currentSession()).toEqual(updated);
+  });
+
+  it('start() leaves currentSession unchanged on 409', () => {
+    let status: number | undefined;
+
+    service.start().subscribe({
+      next:  () => {},
+      error: err => (status = err.status),
+    });
+
+    http.expectOne(base).flush(
+      { errorMessage: 'already running' },
+      { status: 409, statusText: 'Conflict' });
+
+    expect(status).toBe(409);
+    expect(service.currentSession()).toBeNull();
+  });
+});

--- a/Sources/Stockflow.Console/src/app/core/services/sessions.service.ts
+++ b/Sources/Stockflow.Console/src/app/core/services/sessions.service.ts
@@ -1,0 +1,39 @@
+import { Injectable, inject, signal } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, tap } from 'rxjs';
+
+import { REST_BASE } from '../config';
+import { SessionInfo } from '../models/session';
+
+@Injectable({ providedIn: 'root' })
+export class SessionsService {
+  private http = inject(HttpClient);
+  private base = `${REST_BASE}/api/sessions`;
+
+  /** Sessione attualmente nota al client (sincronizzata dalle risposte REST). */
+  readonly currentSession = signal<SessionInfo | null>(null);
+
+  start(): Observable<SessionInfo> {
+    return this.http.post<SessionInfo>(this.base, null).pipe(
+      tap(info => this.currentSession.set(info)),
+    );
+  }
+
+  refresh(id: string): Observable<SessionInfo> {
+    return this.http.get<SessionInfo>(`${this.base}/${id}`).pipe(
+      tap(info => this.currentSession.set(info)),
+    );
+  }
+
+  terminate(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.base}/${id}`).pipe(
+      tap(() => this.currentSession.set(null)),
+    );
+  }
+
+  loadScenario(id: string, scenarioId: string): Observable<SessionInfo> {
+    return this.http
+      .post<SessionInfo>(`${this.base}/${id}/scenario/load`, { scenarioId })
+      .pipe(tap(info => this.currentSession.set(info)));
+  }
+}

--- a/Sources/Stockflow.Console/src/app/core/services/sim-state.service.ts
+++ b/Sources/Stockflow.Console/src/app/core/services/sim-state.service.ts
@@ -7,8 +7,8 @@ import {
   StateDeltaMessage, FullStateMessage,
 } from '../models/protocol';
 import { MockEvent, INITIAL_EVENTS, genSpark } from '../mock/sim-mock';
+import { REST_BASE } from '../config';
 
-const REST_BASE = 'http://localhost:9601';
 const MAX_EVENTS = 120;
 
 @Injectable({ providedIn: 'root' })

--- a/Sources/Stockflow.Console/src/app/core/services/websocket.service.ts
+++ b/Sources/Stockflow.Console/src/app/core/services/websocket.service.ts
@@ -5,8 +5,7 @@ import {
   ServerMessage, StateDeltaMessage, FullStateMessage, CommandResultMessage,
   EntityState, ComponentState, SimEvent, MetricsSnapshot, Direction, EntityStatus,
 } from '../models/protocol';
-
-const WS_URL = 'ws://localhost:9600/ws';
+import { WS_URL } from '../config';
 
 @Injectable({ providedIn: 'root' })
 export class WebSocketService implements OnDestroy {

--- a/Sources/Stockflow.Console/src/app/features/scenarios-panel/scenarios-panel.component.ts
+++ b/Sources/Stockflow.Console/src/app/features/scenarios-panel/scenarios-panel.component.ts
@@ -1,0 +1,197 @@
+import { Component, EventEmitter, OnInit, Output, inject, signal } from '@angular/core';
+import { NgFor, NgIf } from '@angular/common';
+
+import { ScenariosService } from '../../core/services/scenarios.service';
+import { SessionsService }  from '../../core/services/sessions.service';
+import { ScenarioSummary }  from '../../core/models/scenario';
+
+@Component({
+  selector: 'app-scenarios-panel',
+  standalone: true,
+  imports: [NgFor, NgIf],
+  template: `
+    <div class="backdrop" (click)="close.emit()"></div>
+    <div class="panel" (click)="$event.stopPropagation()">
+      <div class="head">
+        <span>SCENARIOS</span>
+        <span class="hint" *ngIf="!hasSession()">No active session — Start one from the topbar to load.</span>
+        <span class="spacer"></span>
+        <button class="btn ghost" (click)="reload()" [disabled]="loading()">REFRESH</button>
+        <button class="btn ghost" (click)="close.emit()" aria-label="close">×</button>
+      </div>
+
+      <div class="body">
+        <div class="empty" *ngIf="!loading() && scenarios().length === 0 && !error()">
+          No scenarios on disk. Create one with
+          <code>POST /api/scenarios</code>.
+        </div>
+        <div class="empty err" *ngIf="error()">{{ error() }}</div>
+        <div class="empty" *ngIf="loading()">Loading…</div>
+
+        <table *ngIf="scenarios().length > 0">
+          <thead>
+            <tr><th>ID</th><th>NAME</th><th>DESCRIPTION</th><th></th></tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let s of scenarios()">
+              <td class="amber mono">{{ s.id }}</td>
+              <td>{{ s.name }}</td>
+              <td class="dim">{{ s.description || '—' }}</td>
+              <td class="actions">
+                <button class="btn primary"
+                        [disabled]="!hasSession() || busy()"
+                        (click)="onLoad(s)">LOAD</button>
+                <button class="btn danger"
+                        [disabled]="busy()"
+                        (click)="onDelete(s)">DELETE</button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  `,
+  styles: [`
+    :host {
+      position: fixed; inset: 0;
+      z-index: 100;
+      font-family: var(--mono);
+    }
+    .backdrop {
+      position: absolute; inset: 0;
+      background: rgba(0,0,0,.55);
+    }
+    .panel {
+      position: relative;
+      margin: 8vh auto;
+      max-width: 720px;
+      max-height: 80vh;
+      background: var(--bg-1);
+      border: 1px solid var(--border-bright);
+      box-shadow: 0 10px 30px rgba(0,0,0,.6);
+      display: flex;
+      flex-direction: column;
+    }
+    .head {
+      display: flex; align-items: center; gap: 10px;
+      padding: 0 10px;
+      height: 32px;
+      background: var(--bg-2);
+      border-bottom: 1px solid var(--border);
+      font-size: 11px;
+      letter-spacing: .1em;
+      color: var(--amber);
+    }
+    .head .hint {
+      color: var(--text-3);
+      letter-spacing: 0;
+      font-weight: normal;
+      font-size: 10px;
+    }
+    .head .spacer { flex: 1; }
+    .body {
+      padding: 10px;
+      overflow: auto;
+    }
+    .empty {
+      padding: 20px;
+      color: var(--text-3);
+      text-align: center;
+      font-size: 11px;
+    }
+    .empty.err { color: var(--red); }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 11px;
+    }
+    th, td {
+      text-align: left;
+      padding: 6px 8px;
+      border-bottom: 1px solid var(--border);
+    }
+    th {
+      color: var(--text-3);
+      font-weight: 500;
+      letter-spacing: .1em;
+      font-size: 9px;
+    }
+    td.dim   { color: var(--text-3); }
+    td.mono  { font-family: var(--mono); }
+    td.amber { color: var(--amber); }
+    .actions { text-align: right; white-space: nowrap; }
+    .btn {
+      background: transparent;
+      border: 1px solid var(--border-bright);
+      color: var(--text-1);
+      font-family: var(--mono);
+      font-size: 10px;
+      letter-spacing: .1em;
+      padding: 4px 10px;
+      cursor: pointer;
+      margin-left: 6px;
+    }
+    .btn:hover:not(:disabled) { background: var(--bg-2); }
+    .btn:disabled { opacity: .35; cursor: not-allowed; }
+    .btn.primary { border-color: var(--amber); color: var(--amber); }
+    .btn.danger  { border-color: var(--red); color: var(--red); }
+    .btn.ghost   { border: none; color: var(--text-3); padding: 2px 8px; }
+    .btn.ghost:hover { color: var(--text-1); }
+  `],
+})
+export class ScenariosPanelComponent implements OnInit {
+  @Output() close = new EventEmitter<void>();
+
+  private scenariosSvc = inject(ScenariosService);
+  private sessionsSvc  = inject(SessionsService);
+
+  readonly scenarios = signal<ScenarioSummary[]>([]);
+  readonly loading   = signal(false);
+  readonly busy      = signal(false);
+  readonly error     = signal<string | null>(null);
+
+  readonly hasSession = () =>
+    this.sessionsSvc.currentSession()?.status === 'Running';
+
+  ngOnInit(): void { this.reload(); }
+
+  reload(): void {
+    this.loading.set(true);
+    this.error.set(null);
+    this.scenariosSvc.list().subscribe({
+      next: list => { this.scenarios.set(list); this.loading.set(false); },
+      error: err => {
+        this.error.set(`Load failed: HTTP ${err.status ?? '?'}`);
+        this.loading.set(false);
+      },
+    });
+  }
+
+  onLoad(s: ScenarioSummary): void {
+    const session = this.sessionsSvc.currentSession();
+    if (!session || session.status !== 'Running') return;
+    this.busy.set(true);
+    this.sessionsSvc.loadScenario(session.id, s.id).subscribe({
+      next: () => { this.busy.set(false); this.close.emit(); },
+      error: err => {
+        this.error.set(`Load '${s.id}' failed: HTTP ${err.status ?? '?'}`);
+        this.busy.set(false);
+      },
+    });
+  }
+
+  onDelete(s: ScenarioSummary): void {
+    if (!confirm(`Delete scenario '${s.id}'?`)) return;
+    this.busy.set(true);
+    this.scenariosSvc.delete(s.id).subscribe({
+      next: () => {
+        this.scenarios.update(xs => xs.filter(x => x.id !== s.id));
+        this.busy.set(false);
+      },
+      error: err => {
+        this.error.set(`Delete '${s.id}' failed: HTTP ${err.status ?? '?'}`);
+        this.busy.set(false);
+      },
+    });
+  }
+}

--- a/Sources/Stockflow.Console/src/app/features/scenarios-panel/scenarios-panel.component.ts
+++ b/Sources/Stockflow.Console/src/app/features/scenarios-panel/scenarios-panel.component.ts
@@ -3,7 +3,11 @@ import { NgFor, NgIf } from '@angular/common';
 
 import { ScenariosService } from '../../core/services/scenarios.service';
 import { SessionsService }  from '../../core/services/sessions.service';
-import { ScenarioSummary }  from '../../core/models/scenario';
+import { SimStateService }  from '../../core/services/sim-state.service';
+import { Scenario, ScenarioSummary, PreplacedComponent } from '../../core/models/scenario';
+import { ComponentState }  from '../../core/models/protocol';
+
+const ID_PATTERN = /^[a-zA-Z0-9._-]{1,64}$/;
 
 @Component({
   selector: 'app-scenarios-panel',
@@ -16,6 +20,12 @@ import { ScenarioSummary }  from '../../core/models/scenario';
         <span>SCENARIOS</span>
         <span class="hint" *ngIf="!hasSession()">No active session — Start one from the topbar to load.</span>
         <span class="spacer"></span>
+        <button class="btn primary"
+                (click)="onSaveCurrent()"
+                [disabled]="busy() || sim.components().size === 0"
+                title="Snapshot the current grid + placed components as a new scenario">
+          SAVE CURRENT
+        </button>
         <button class="btn ghost" (click)="reload()" [disabled]="loading()">REFRESH</button>
         <button class="btn ghost" (click)="close.emit()" aria-label="close">×</button>
       </div>
@@ -144,6 +154,7 @@ export class ScenariosPanelComponent implements OnInit {
 
   private scenariosSvc = inject(ScenariosService);
   private sessionsSvc  = inject(SessionsService);
+  readonly sim         = inject(SimStateService);
 
   readonly scenarios = signal<ScenarioSummary[]>([]);
   readonly loading   = signal(false);
@@ -194,4 +205,50 @@ export class ScenariosPanelComponent implements OnInit {
       },
     });
   }
+
+  /**
+   * Snapshot dello stato corrente (grid + componenti piazzati) come nuovo
+   * scenario. Le proprietà configurabili (spawnRate, sku, speed, turn, ...)
+   * NON sono incluse perché il formato §6.1 dei preplacedComponents non le
+   * prevede; al ricarico i componenti partiranno con i parametri di default.
+   */
+  onSaveCurrent(): void {
+    const id = prompt('Scenario id (a-z A-Z 0-9 . _ -, max 64 chars):')?.trim();
+    if (!id) return;
+    if (!ID_PATTERN.test(id)) {
+      this.error.set(`Invalid id '${id}' — allowed: a-z A-Z 0-9 . _ - up to 64 chars`);
+      return;
+    }
+    const name = prompt('Scenario name:', id)?.trim();
+    if (!name) return;
+
+    const components = Array.from(this.sim.components().values());
+    const scenario: Scenario = {
+      id,
+      name,
+      gridSize: { width: this.sim.gridWidth(), height: this.sim.gridLength() },
+      preplacedComponents: components.map(toPreplaced),
+    };
+
+    this.busy.set(true);
+    this.error.set(null);
+    this.scenariosSvc.create(scenario).subscribe({
+      next: () => { this.busy.set(false); this.reload(); },
+      error: err => {
+        const msg = err.status === 409
+          ? `Scenario '${id}' already exists`
+          : `Save failed: HTTP ${err.status ?? '?'}`;
+        this.error.set(msg);
+        this.busy.set(false);
+      },
+    });
+  }
+}
+
+function toPreplaced(c: ComponentState): PreplacedComponent {
+  return {
+    type:      c.kind,
+    position:  [c.gridX, c.gridY],
+    direction: (c.facing ?? 'North').toLowerCase(),
+  };
 }

--- a/Sources/Stockflow.Console/src/app/features/topbar/topbar.component.ts
+++ b/Sources/Stockflow.Console/src/app/features/topbar/topbar.component.ts
@@ -1,5 +1,7 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
-import { NgFor } from '@angular/common';
+import { Component, EventEmitter, Input, Output, computed, inject } from '@angular/core';
+import { NgFor, NgIf } from '@angular/common';
+
+import { SessionsService } from '../../core/services/sessions.service';
 
 export type Tab = 'LAYOUT' | 'OPERATE' | 'ORDERS' | 'METRICS' | 'WORKSHOP' | 'PRO';
 const TABS: { id: Tab; key: string }[] = [
@@ -14,7 +16,7 @@ const TABS: { id: Tab; key: string }[] = [
 @Component({
   selector: 'app-topbar',
   standalone: true,
-  imports: [NgFor],
+  imports: [NgFor, NgIf],
   template: `
     <div class="topbar">
       <div class="brand">STOCKFLOW<span class="sub">·CON</span></div>
@@ -30,7 +32,33 @@ const TABS: { id: Tab; key: string }[] = [
                 [style.box-shadow]="connected ? '0 0 6px var(--green)' : 'none'"></span>
           {{ connected ? 'SIM ACTIVE' : 'DISCONNECTED' }}
         </span>
-        <span>SESSION <span class="amber">#A4B21</span></span>
+
+        <!-- ── Session indicator + lifecycle controls ────────────────── -->
+        <ng-container *ngIf="sessions.currentSession(); else noSession">
+          <span>
+            SESSION
+            <span [class.amber]="isRunning()" [class.dim2]="!isRunning()">
+              #{{ shortId() }}
+            </span>
+            <span class="dim2"> · {{ statusLabel() }}</span>
+          </span>
+          <button class="mini-btn"
+                  (click)="onTerminate()"
+                  *ngIf="isRunning()"
+                  [disabled]="busy">STOP</button>
+          <button class="mini-btn"
+                  (click)="onStart()"
+                  *ngIf="!isRunning()"
+                  [disabled]="busy">START</button>
+        </ng-container>
+        <ng-template #noSession>
+          <span class="dim">SESSION <span class="dim2">none</span></span>
+          <button class="mini-btn" (click)="onStart()" [disabled]="busy">START</button>
+        </ng-template>
+
+        <button class="mini-btn"
+                (click)="openScenarios.emit()">SCENARIOS</button>
+
         <span class="live-chip">
           <span class="dot" [style.background]="connected ? 'var(--green)' : 'var(--red-dim)'"></span>
           WS :9600
@@ -103,13 +131,61 @@ const TABS: { id: Tab; key: string }[] = [
       flex-shrink: 0;
     }
     .live-chip { display: flex; align-items: center; }
+    .mini-btn {
+      background: transparent;
+      border: 1px solid var(--border-bright);
+      color: var(--text-1);
+      font-family: var(--mono);
+      font-size: 9px;
+      letter-spacing: .1em;
+      padding: 2px 6px;
+      cursor: pointer;
+    }
+    .mini-btn:hover:not(:disabled) { background: var(--bg-2); color: var(--amber); border-color: var(--amber); }
+    .mini-btn:disabled { opacity: .35; cursor: not-allowed; }
+    .dim  { color: var(--text-3); }
+    .dim2 { color: var(--text-3); opacity: .7; }
+    .amber { color: var(--amber); }
   `],
 })
 export class TopbarComponent {
   @Input() activeTab: Tab = 'OPERATE';
   @Input() connected = false;
   @Input() restOnline = false;
-  @Output() tabChange = new EventEmitter<Tab>();
+  @Output() tabChange     = new EventEmitter<Tab>();
+  @Output() openScenarios = new EventEmitter<void>();
 
   readonly tabs = TABS;
+  readonly sessions = inject(SessionsService);
+
+  busy = false;
+
+  readonly shortId = computed(() => {
+    const id = this.sessions.currentSession()?.id;
+    return id ? id.slice(0, 5).toUpperCase() : '';
+  });
+
+  readonly isRunning = computed(() =>
+    this.sessions.currentSession()?.status === 'Running');
+
+  readonly statusLabel = computed(() =>
+    this.sessions.currentSession()?.status?.toUpperCase() ?? '');
+
+  onStart(): void {
+    this.busy = true;
+    this.sessions.start().subscribe({
+      next: () => (this.busy = false),
+      error: () => (this.busy = false),
+    });
+  }
+
+  onTerminate(): void {
+    const s = this.sessions.currentSession();
+    if (!s) return;
+    this.busy = true;
+    this.sessions.terminate(s.id).subscribe({
+      next: () => (this.busy = false),
+      error: () => (this.busy = false),
+    });
+  }
 }

--- a/Sources/Stockflow.Simulation/Commands/LoadScenarioCommand.cs
+++ b/Sources/Stockflow.Simulation/Commands/LoadScenarioCommand.cs
@@ -1,0 +1,8 @@
+namespace Stockflow.Simulation.Commands;
+
+public sealed record LoadScenarioCommand(
+    int                     Width,
+    int                     Length,
+    int                     Floors,
+    IReadOnlyList<ICommand> Preplaced
+) : ICommand;

--- a/Sources/Stockflow.Simulation/Core/SimulationClock.cs
+++ b/Sources/Stockflow.Simulation/Core/SimulationClock.cs
@@ -16,4 +16,11 @@ public class SimulationClock
     {
         _simulatedTime += delta;
     }
+
+    // Azzera il tempo simulato preservando TimeScale (la velocità di playback
+    // appartiene alla preferenza utente, non allo scenario).
+    public void Reset()
+    {
+        _simulatedTime = 0f;
+    }
 }

--- a/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
+++ b/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
@@ -51,8 +51,8 @@ public class SimulationEngine
     public SimulationClock Clock          { get; }
     public float           TimeScale      { get => Clock.TimeScale; set => Clock.TimeScale = value; }
     public float           SimulationTime => Clock.SimulatedTime;
-    public GridManager     Grid           { get; }
-    public RoutingGraph    Graph          { get; }
+    public GridManager     Grid           { get; private set; }
+    public RoutingGraph    Graph          { get; private set; }
     public SimulationState State          { get; }
 
     // deltaTime è calcolato dal caller: 1f / tickRate * engine.TimeScale
@@ -72,8 +72,39 @@ public class SimulationEngine
         {
             ConfigureComponentCommand cmd => ConfigureComponent(cmd),
             RemoveComponentCommand    cmd => RemoveComponent(cmd),
+            LoadScenarioCommand       cmd => LoadScenario(cmd),
             _                              => CommandResult.Fail($"Unknown command: {command.GetType().Name}"),
         };
+    }
+
+    private CommandResult LoadScenario(LoadScenarioCommand cmd)
+    {
+        if (cmd.Width <= 0 || cmd.Length <= 0 || cmd.Floors <= 0)
+            return CommandResult.Fail($"Scenario dimensions must be positive (got {cmd.Width}x{cmd.Length}x{cmd.Floors})");
+
+        ResetAndLoad(cmd.Width, cmd.Length, cmd.Floors);
+
+        for (var i = 0; i < cmd.Preplaced.Count; i++)
+        {
+            var pre    = cmd.Preplaced[i];
+            var result = ProcessCommand(pre);
+            if (!result.Success)
+                return CommandResult.Fail($"Preplaced component {i} ({pre.GetType().Name}) failed: {result.ErrorMessage}");
+        }
+
+        return CommandResult.Ok();
+    }
+
+    // Wipe lo stato del mondo lasciando crescere i counter ID monotonici:
+    // così GetStateDelta riporta correttamente le vecchie ID come rimosse e
+    // le nuove come aggiunte, senza collisioni cross-scenario.
+    private void ResetAndLoad(int width, int length, int floors)
+    {
+        Grid  = new GridManager(width, length, floors);
+        Graph = new RoutingGraph();
+        State.Components.Clear();
+        State.Entities.Reset();
+        Clock.Reset();
     }
 
     private CommandResult PlaceComponent(ICommand cmd, Func<ICommand, int, ISimComponent> factory)

--- a/Sources/Stockflow.Simulation/Entity/EntityManager.cs
+++ b/Sources/Stockflow.Simulation/Entity/EntityManager.cs
@@ -42,4 +42,16 @@ public class EntityManager
         _pool.Enqueue(entity);
         return true;
     }
+
+    // Svuota le entità attive (riusando il pool) preservando _nextId per
+    // evitare collisioni di ID con le entità segnalate da GetStateDelta.
+    public void Reset()
+    {
+        foreach (var entity in _active.Values)
+        {
+            entity.Reset();
+            _pool.Enqueue(entity);
+        }
+        _active.Clear();
+    }
 }

--- a/Sources/Stockflow.Tests.Simulation/LoadScenarioCommandTests.cs
+++ b/Sources/Stockflow.Tests.Simulation/LoadScenarioCommandTests.cs
@@ -1,0 +1,160 @@
+using Stockflow.Simulation.Commands;
+using Stockflow.Simulation.Component;
+using Stockflow.Simulation.Core;
+using Stockflow.Simulation.Grid;
+
+namespace Stockflow.Tests.Simulation;
+
+public class LoadScenarioCommandTests
+{
+    private static SimulationEngine MakeEngine() => new(10, 10, 1);
+
+    [Fact]
+    public void Load_ChangesGridDimensions()
+    {
+        var engine = MakeEngine();
+
+        var result = engine.ProcessCommand(new LoadScenarioCommand(
+            Width:     20,
+            Length:    15,
+            Floors:    2,
+            Preplaced: []));
+
+        Assert.True(result.Success);
+        Assert.Equal(20, engine.Grid.Width);
+        Assert.Equal(15, engine.Grid.Length);
+        Assert.Equal(2,  engine.Grid.Height);
+    }
+
+    [Fact]
+    public void Load_ClearsPreviousComponentsAndEntities()
+    {
+        var engine = MakeEngine();
+        engine.ProcessCommand(new PlacePackageGeneratorCommand(
+            new GridCoord(0, 0), Direction.North, SpawnRate: 1f));
+        engine.Tick(1f);  // spawn an entity
+
+        Assert.NotEmpty(engine.State.Components);
+        Assert.NotEmpty(engine.State.Entities.Active);
+
+        engine.ProcessCommand(new LoadScenarioCommand(5, 5, 1, []));
+
+        Assert.Empty(engine.State.Components);
+        Assert.Empty(engine.State.Entities.Active);
+    }
+
+    [Fact]
+    public void Load_ResetsSimulationTime_PreservesTimeScale()
+    {
+        var engine = MakeEngine();
+        engine.TimeScale = 5f;
+        engine.Tick(2.5f);
+
+        Assert.Equal(2.5f, engine.SimulationTime, precision: 5);
+
+        engine.ProcessCommand(new LoadScenarioCommand(5, 5, 1, []));
+
+        Assert.Equal(0f, engine.SimulationTime);
+        Assert.Equal(5f, engine.TimeScale);  // velocità di playback è preferenza utente
+    }
+
+    [Fact]
+    public void Load_PlacesPreplacedComponentsAtCorrectPositions()
+    {
+        var engine = MakeEngine();
+
+        engine.ProcessCommand(new LoadScenarioCommand(10, 10, 1,
+        [
+            new PlacePackageGeneratorCommand(new GridCoord(0, 0), Direction.East),
+            new PlaceOneWayConveyorCommand(new GridCoord(1, 0), Direction.East),
+            new PlacePackageExitCommand(new GridCoord(2, 0), Direction.East),
+        ]));
+
+        Assert.Equal(3, engine.State.Components.Count);
+        Assert.IsType<PackageGenerator>(engine.State.Components[0]);
+        Assert.IsType<OneWayConveyor>(engine.State.Components[1]);
+        Assert.IsType<PackageExit>(engine.State.Components[2]);
+        Assert.Equal(new GridCoord(0, 0), engine.State.Components[0].Position);
+        Assert.Equal(new GridCoord(1, 0), engine.State.Components[1].Position);
+        Assert.Equal(new GridCoord(2, 0), engine.State.Components[2].Position);
+    }
+
+    [Fact]
+    public void Load_WithEmptyPreplaced_Succeeds()
+    {
+        var engine = MakeEngine();
+
+        var result = engine.ProcessCommand(new LoadScenarioCommand(8, 8, 1, []));
+
+        Assert.True(result.Success);
+        Assert.Empty(engine.State.Components);
+    }
+
+    [Theory]
+    [InlineData( 0, 10, 1)]
+    [InlineData(10,  0, 1)]
+    [InlineData(10, 10, 0)]
+    [InlineData(-1, 10, 1)]
+    public void Load_WithNonPositiveDimensions_Fails(int width, int length, int floors)
+    {
+        var engine = MakeEngine();
+
+        var result = engine.ProcessCommand(new LoadScenarioCommand(width, length, floors, []));
+
+        Assert.False(result.Success);
+        Assert.Contains("positive", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Load_WithOutOfBoundsPreplaced_Fails()
+    {
+        var engine = MakeEngine();
+
+        var result = engine.ProcessCommand(new LoadScenarioCommand(5, 5, 1,
+        [
+            new PlacePackageGeneratorCommand(new GridCoord(99, 99), Direction.North),
+        ]));
+
+        Assert.False(result.Success);
+        Assert.Contains("Preplaced", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Load_FollowedByGetStateDelta_ReportsOldIdsRemoved_NewIdsAdded()
+    {
+        var engine = MakeEngine();
+        engine.ProcessCommand(new PlacePackageGeneratorCommand(
+            new GridCoord(0, 0), Direction.North));
+        var oldId = engine.State.Components[0].Id;
+        engine.GetStateDelta();  // baseline: oldId è ora "known"
+
+        engine.ProcessCommand(new LoadScenarioCommand(10, 10, 1,
+        [
+            new PlacePackageExitCommand(new GridCoord(2, 2), Direction.East),
+        ]));
+
+        var delta = engine.GetStateDelta();
+        var newId = engine.State.Components[0].Id;
+
+        Assert.Contains(oldId, delta.RemovedComponentIds);
+        Assert.Contains(newId, delta.AddedComponentIds);
+        Assert.NotEqual(oldId, newId);  // ID monotonici, no collision
+    }
+
+    [Fact]
+    public void Load_AfterLoad_GridIsFreshForPlacements()
+    {
+        // Verifica che le celle del vecchio grid siano davvero rilasciate:
+        // se non lo fossero, una placement sulla stessa coord fallirebbe.
+        var engine = MakeEngine();
+        engine.ProcessCommand(new PlacePackageGeneratorCommand(
+            new GridCoord(3, 3), Direction.North));
+
+        engine.ProcessCommand(new LoadScenarioCommand(10, 10, 1, []));
+
+        var result = engine.ProcessCommand(new PlacePackageGeneratorCommand(
+            new GridCoord(3, 3), Direction.North));
+
+        Assert.True(result.Success);
+    }
+}

--- a/Sources/Stockflow.Webserver/Configuration/ServerConfig.cs
+++ b/Sources/Stockflow.Webserver/Configuration/ServerConfig.cs
@@ -25,6 +25,12 @@ public sealed class ServerConfig
     public int GridWidth  { get; set; } = 50;
     public int GridLength { get; set; } = 50;
     public int GridFloors { get; set; } = 1;
+
+    /// <summary>
+    /// Filesystem path for scenario JSON files. Relative paths resolve against
+    /// <see cref="IHostEnvironment.ContentRootPath"/>.
+    /// </summary>
+    public string ScenariosPath { get; set; } = "Scenarios";
 }
 
 public enum ServerMode

--- a/Sources/Stockflow.Webserver/Controllers/ScenarioController.cs
+++ b/Sources/Stockflow.Webserver/Controllers/ScenarioController.cs
@@ -1,0 +1,109 @@
+using Microsoft.AspNetCore.Mvc;
+using Stockflow.Webserver.Scenarios;
+
+namespace Stockflow.Webserver.Controllers;
+
+/// <summary>
+/// CRUD sui file scenario (storage filesystem in <c>ContentRoot/Scenarios/</c>).
+/// Per ARCHITECTURE §6 gli scenari sono file-based, NON passano per il database.
+/// </summary>
+[ApiController]
+[Route("api/scenarios")]
+public sealed class ScenarioController(
+    IScenarioRepository         repository,
+    ILogger<ScenarioController> logger) : ControllerBase
+{
+    [HttpGet]
+    public IActionResult List()
+    {
+        var summaries = repository.List().ToList();
+        logger.LogDebug("GET /api/scenarios → {Count} scenarios", summaries.Count);
+        return Ok(summaries);
+    }
+
+    [HttpGet("{id}")]
+    public IActionResult Get(string id)
+    {
+        try
+        {
+            var scenario = repository.Get(id);
+            if (scenario is null)
+            {
+                logger.LogDebug("GET /api/scenarios/{Id} → 404", id);
+                return NotFound(new { errorMessage = $"Scenario '{id}' not found" });
+            }
+            return Ok(scenario);
+        }
+        catch (InvalidScenarioIdException ex)
+        {
+            logger.LogWarning("GET /api/scenarios/{Id} → 400 invalid id", id);
+            return BadRequest(new { errorMessage = ex.Message });
+        }
+    }
+
+    [HttpPost]
+    public IActionResult Create([FromBody] Scenario scenario)
+    {
+        try
+        {
+            repository.Create(scenario);
+            logger.LogInformation("POST /api/scenarios → created '{Id}'", scenario.Id);
+            return CreatedAtAction(nameof(Get), new { id = scenario.Id }, scenario);
+        }
+        catch (InvalidScenarioIdException ex)
+        {
+            logger.LogWarning("POST /api/scenarios → 400 invalid id '{Id}'", scenario.Id);
+            return BadRequest(new { errorMessage = ex.Message });
+        }
+        catch (ScenarioAlreadyExistsException ex)
+        {
+            logger.LogWarning("POST /api/scenarios → 409 '{Id}' already exists", scenario.Id);
+            return Conflict(new { errorMessage = ex.Message });
+        }
+    }
+
+    [HttpPut("{id}")]
+    public IActionResult Update(string id, [FromBody] Scenario scenario)
+    {
+        if (!string.Equals(id, scenario.Id, StringComparison.Ordinal))
+        {
+            logger.LogWarning("PUT /api/scenarios/{Id} → 400 body id '{BodyId}' mismatch", id, scenario.Id);
+            return BadRequest(new { errorMessage = $"Body id '{scenario.Id}' does not match route id '{id}'" });
+        }
+
+        try
+        {
+            repository.Update(scenario);
+            logger.LogInformation("PUT /api/scenarios/{Id} → updated", id);
+            return Ok(scenario);
+        }
+        catch (InvalidScenarioIdException ex)
+        {
+            return BadRequest(new { errorMessage = ex.Message });
+        }
+        catch (ScenarioNotFoundException ex)
+        {
+            logger.LogWarning("PUT /api/scenarios/{Id} → 404", id);
+            return NotFound(new { errorMessage = ex.Message });
+        }
+    }
+
+    [HttpDelete("{id}")]
+    public IActionResult Delete(string id)
+    {
+        try
+        {
+            if (!repository.Delete(id))
+            {
+                logger.LogWarning("DELETE /api/scenarios/{Id} → 404", id);
+                return NotFound(new { errorMessage = $"Scenario '{id}' not found" });
+            }
+            logger.LogInformation("DELETE /api/scenarios/{Id} → deleted", id);
+            return NoContent();
+        }
+        catch (InvalidScenarioIdException ex)
+        {
+            return BadRequest(new { errorMessage = ex.Message });
+        }
+    }
+}

--- a/Sources/Stockflow.Webserver/Controllers/SessionController.cs
+++ b/Sources/Stockflow.Webserver/Controllers/SessionController.cs
@@ -1,0 +1,169 @@
+using Microsoft.AspNetCore.Mvc;
+using Stockflow.Simulation.Commands;
+using Stockflow.Simulation.Grid;
+using Stockflow.Webserver.Queue;
+using Stockflow.Webserver.Scenarios;
+using Stockflow.Webserver.Serialization;
+using Stockflow.Webserver.Sessions;
+
+namespace Stockflow.Webserver.Controllers;
+
+/// <summary>
+/// Lifecycle della sessione di simulazione (modello F1A: singola sessione attiva).
+/// Le operazioni mutative sull'engine vengono enqueueate al tick loop via
+/// <see cref="IRestCommandQueue"/>.
+/// </summary>
+[ApiController]
+[Route("api/sessions")]
+public sealed class SessionController(
+    ISessionManager              sessions,
+    IScenarioRepository          scenarios,
+    IRestCommandQueue            queue,
+    ILogger<SessionController>   logger) : ControllerBase
+{
+    [HttpPost]
+    public IActionResult Start()
+    {
+        try
+        {
+            var info = sessions.Start();
+            logger.LogInformation("POST /api/sessions → started {Id}", info.Id);
+            return CreatedAtAction(nameof(Get), new { id = info.Id }, info);
+        }
+        catch (SessionAlreadyActiveException ex)
+        {
+            logger.LogWarning("POST /api/sessions → 409 already active ({Id})", ex.CurrentId);
+            return Conflict(new { errorMessage = ex.Message });
+        }
+    }
+
+    [HttpGet("{id:guid}")]
+    public IActionResult Get(Guid id)
+    {
+        var current = sessions.Current;
+        if (current is null || current.Id != id)
+        {
+            logger.LogDebug("GET /api/sessions/{Id} → 404", id);
+            return NotFound(new { errorMessage = $"Session '{id}' not found" });
+        }
+        return Ok(current);
+    }
+
+    [HttpDelete("{id:guid}")]
+    public IActionResult Terminate(Guid id)
+    {
+        if (!sessions.Terminate(id))
+        {
+            logger.LogWarning("DELETE /api/sessions/{Id} → 404", id);
+            return NotFound(new { errorMessage = $"Session '{id}' not found or already terminated" });
+        }
+        logger.LogInformation("DELETE /api/sessions/{Id} → terminated", id);
+        return NoContent();
+    }
+
+    [HttpPost("{id:guid}/scenario/load")]
+    public IActionResult LoadScenario(Guid id, [FromBody] LoadScenarioRequest req)
+    {
+        var current = sessions.Current;
+        if (current is null || current.Id != id || current.Status != SessionStatus.Running)
+        {
+            logger.LogWarning("POST /api/sessions/{Id}/scenario/load → 404 session", id);
+            return NotFound(new { errorMessage = $"Session '{id}' not found or not running" });
+        }
+
+        Scenario? scenario;
+        try
+        {
+            scenario = scenarios.Get(req.ScenarioId);
+        }
+        catch (InvalidScenarioIdException ex)
+        {
+            return BadRequest(new { errorMessage = ex.Message });
+        }
+
+        if (scenario is null)
+        {
+            logger.LogWarning("POST /api/sessions/{Id}/scenario/load → 404 scenario '{Sid}'", id, req.ScenarioId);
+            return NotFound(new { errorMessage = $"Scenario '{req.ScenarioId}' not found" });
+        }
+
+        if (scenario.GridSize is null || scenario.GridSize.Width <= 0 || scenario.GridSize.Height <= 0)
+        {
+            logger.LogWarning("POST /api/sessions/{Id}/scenario/load → 400 missing/invalid gridSize", id);
+            return BadRequest(new { errorMessage = "Scenario must define a positive gridSize" });
+        }
+
+        WarnAboutUnsupportedFields(scenario);
+
+        var preplaced = new List<ICommand>();
+        if (scenario.PreplacedComponents is not null)
+        {
+            for (var i = 0; i < scenario.PreplacedComponents.Count; i++)
+            {
+                var pp  = scenario.PreplacedComponents[i];
+                var cmd = MapPreplaced(pp);
+                if (cmd is null)
+                {
+                    logger.LogWarning(
+                        "Scenario '{Sid}': skipped preplaced #{Index} unknown type '{Type}'",
+                        scenario.Id, i, pp.Type);
+                    continue;
+                }
+                preplaced.Add(cmd);
+            }
+        }
+
+        queue.Enqueue(new LoadScenarioCommand(
+            scenario.GridSize.Width,
+            scenario.GridSize.Height,
+            Floors:    1,
+            Preplaced: preplaced));
+
+        sessions.TryAttachScenario(id, scenario.Id);
+
+        logger.LogInformation(
+            "POST /api/sessions/{Id}/scenario/load → enqueued '{Sid}' ({W}x{H}, {N} preplaced)",
+            id, scenario.Id, scenario.GridSize.Width, scenario.GridSize.Height, preplaced.Count);
+
+        return AcceptedAtAction(nameof(Get), new { id }, sessions.Current);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private static ICommand? MapPreplaced(PreplacedComponent pp)
+    {
+        if (pp.Position is null || pp.Position.Length < 2) return null;
+
+        var pos = new GridCoord(pp.Position[0], pp.Position[1]);
+        var dir = DirectionParser.Parse(pp.Direction);
+
+        return pp.Type?.ToLowerInvariant() switch
+        {
+            "packagegenerator"  or "package_generator" => new PlacePackageGeneratorCommand(pos, dir),
+            "packageexit"       or "package_exit"      => new PlacePackageExitCommand(pos, dir),
+            "onewayconveyor"    or "one_way_conveyor" or "conveyor_straight"
+                => new PlaceOneWayConveyorCommand(pos, dir),
+            "conveyorturn"      or "conveyor_turn" or "conveyor_curve"
+                => new PlaceConveyorTurnCommand(pos, dir),
+            _ => null,
+        };
+    }
+
+    private void WarnAboutUnsupportedFields(Scenario s)
+    {
+        if (s.Budget is not null)
+            logger.LogWarning("Scenario '{Id}': budget is set but the simulation does not yet honor it", s.Id);
+        if (s.AvailableComponents is { Count: > 0 })
+            logger.LogWarning("Scenario '{Id}': availableComponents is set but the simulation does not yet honor it", s.Id);
+        if (s.SkuCatalog is not null)
+            logger.LogWarning("Scenario '{Id}': skuCatalog is set but the simulation does not yet honor it", s.Id);
+        if (s.OrderProfile is not null)
+            logger.LogWarning("Scenario '{Id}': orderProfile is set but the simulation does not yet honor it", s.Id);
+        if (s.Objectives is { Count: > 0 })
+            logger.LogWarning("Scenario '{Id}': objectives is set but the simulation does not yet honor it", s.Id);
+        if (s.Duration is not null)
+            logger.LogWarning("Scenario '{Id}': duration is set but the simulation does not yet honor it", s.Id);
+    }
+}
+
+public sealed record LoadScenarioRequest(string ScenarioId);

--- a/Sources/Stockflow.Webserver/Controllers/SessionController.cs
+++ b/Sources/Stockflow.Webserver/Controllers/SessionController.cs
@@ -141,7 +141,7 @@ public sealed class SessionController(
         {
             "packagegenerator"  or "package_generator" => new PlacePackageGeneratorCommand(pos, dir),
             "packageexit"       or "package_exit"      => new PlacePackageExitCommand(pos, dir),
-            "onewayconveyor"    or "one_way_conveyor" or "conveyor_straight"
+            "onewayconveyor"    or "one_way_conveyor" or "conveyor_straight" or "conveyor_oneway"
                 => new PlaceOneWayConveyorCommand(pos, dir),
             "conveyorturn"      or "conveyor_turn" or "conveyor_curve"
                 => new PlaceConveyorTurnCommand(pos, dir),

--- a/Sources/Stockflow.Webserver/Controllers/SimulationController.cs
+++ b/Sources/Stockflow.Webserver/Controllers/SimulationController.cs
@@ -7,7 +7,6 @@ using Stockflow.Simulation.Grid;
 using Stockflow.Webserver.Configuration;
 using Stockflow.Webserver.Queue;
 using Stockflow.Webserver.Serialization;
-using SimDirection     = Stockflow.Simulation.Component.Direction;
 
 namespace Stockflow.Webserver.Controllers;
 
@@ -113,7 +112,7 @@ public sealed class SimulationController(
     [HttpPost("components")]
     public IActionResult PlaceComponent([FromBody] PlaceComponentRequest req)
     {
-        var dir = ParseDirection(req.Facing);
+        var dir = DirectionParser.Parse(req.Facing);
         var pos = new GridCoord(req.GridX, req.GridY);
 
         ICommand? cmd = req.Kind switch
@@ -177,15 +176,6 @@ public sealed class SimulationController(
         return Accepted();
     }
 
-    // ─────────────────────────────────────────────────────────────────────────
-
-    private static SimDirection ParseDirection(string? s) => s switch
-    {
-        "East"  => SimDirection.East,
-        "South" => SimDirection.South,
-        "West"  => SimDirection.West,
-        _       => SimDirection.North,
-    };
 }
 
 public sealed record ChangeSpeedRequest(int Speed);

--- a/Sources/Stockflow.Webserver/Program.cs
+++ b/Sources/Stockflow.Webserver/Program.cs
@@ -5,6 +5,7 @@ using Stockflow.Simulation.Core;
 using Stockflow.Webserver.Configuration;
 using Stockflow.Webserver.Hosting;
 using Stockflow.Webserver.Queue;
+using Stockflow.Webserver.Scenarios;
 using Stockflow.Webserver.WebSocket;
 
 MessagePackConfig.Initialize();
@@ -37,6 +38,12 @@ builder.Services.AddSingleton<SimulationEngine>(sp =>
 {
     var cfg = sp.GetRequiredService<IOptions<ServerConfig>>().Value;
     return new SimulationEngine(cfg.GridWidth, cfg.GridLength, cfg.GridFloors);
+});
+builder.Services.AddSingleton<IScenarioRepository>(sp =>
+{
+    var env  = sp.GetRequiredService<IHostEnvironment>();
+    var path = Path.Combine(env.ContentRootPath, "Scenarios");
+    return new FileScenarioRepository(path);
 });
 builder.Services.AddHostedService<SimulationHostedService>();
 

--- a/Sources/Stockflow.Webserver/Program.cs
+++ b/Sources/Stockflow.Webserver/Program.cs
@@ -6,6 +6,7 @@ using Stockflow.Webserver.Configuration;
 using Stockflow.Webserver.Hosting;
 using Stockflow.Webserver.Queue;
 using Stockflow.Webserver.Scenarios;
+using Stockflow.Webserver.Sessions;
 using Stockflow.Webserver.WebSocket;
 
 MessagePackConfig.Initialize();
@@ -45,6 +46,7 @@ builder.Services.AddSingleton<IScenarioRepository>(sp =>
     var path = Path.Combine(env.ContentRootPath, "Scenarios");
     return new FileScenarioRepository(path);
 });
+builder.Services.AddSingleton<ISessionManager, SessionManager>();
 builder.Services.AddHostedService<SimulationHostedService>();
 
 builder.Services.AddControllers();

--- a/Sources/Stockflow.Webserver/Program.cs
+++ b/Sources/Stockflow.Webserver/Program.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Options;
 using Stockflow.Protocol.Serialization;
@@ -42,14 +43,24 @@ builder.Services.AddSingleton<SimulationEngine>(sp =>
 });
 builder.Services.AddSingleton<IScenarioRepository>(sp =>
 {
+    var cfg  = sp.GetRequiredService<IOptions<ServerConfig>>().Value;
     var env  = sp.GetRequiredService<IHostEnvironment>();
-    var path = Path.Combine(env.ContentRootPath, "Scenarios");
+    var path = Path.IsPathRooted(cfg.ScenariosPath)
+        ? cfg.ScenariosPath
+        : Path.Combine(env.ContentRootPath, cfg.ScenariosPath);
     return new FileScenarioRepository(path);
 });
 builder.Services.AddSingleton<ISessionManager, SessionManager>();
 builder.Services.AddHostedService<SimulationHostedService>();
 
-builder.Services.AddControllers();
+builder.Services
+    .AddControllers()
+    .AddJsonOptions(o =>
+    {
+        // Enum come stringa (es. SessionStatus → "Running"/"Terminated") per
+        // mantenere il payload REST stabile e self-describing per il client.
+        o.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 
 // Local mode: allow any origin so the Angular dev server (default :4200) can reach the REST API.
 // Enterprise mode would restrict this to known origins via config.

--- a/Sources/Stockflow.Webserver/Scenarios/FileScenarioRepository.cs
+++ b/Sources/Stockflow.Webserver/Scenarios/FileScenarioRepository.cs
@@ -1,0 +1,109 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Stockflow.Webserver.Scenarios;
+
+public sealed partial class FileScenarioRepository : IScenarioRepository
+{
+    private static readonly Regex IdPattern = ScenarioIdRegex();
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented        = true,
+    };
+
+    private readonly string _scenariosPath;
+    private readonly object _lock = new();
+
+    public FileScenarioRepository(string scenariosPath)
+    {
+        _scenariosPath = scenariosPath;
+        Directory.CreateDirectory(_scenariosPath);
+    }
+
+    public IEnumerable<ScenarioSummary> List()
+    {
+        lock (_lock)
+        {
+            var files = Directory.EnumerateFiles(_scenariosPath, "*.json");
+            var summaries = new List<ScenarioSummary>();
+            foreach (var file in files)
+            {
+                var s = ReadFile(file);
+                if (s != null)
+                    summaries.Add(new ScenarioSummary(s.Id, s.Name, s.Description));
+            }
+            return summaries;
+        }
+    }
+
+    public Scenario? Get(string id)
+    {
+        ValidateId(id);
+        lock (_lock)
+        {
+            var path = PathFor(id);
+            return File.Exists(path) ? ReadFile(path) : null;
+        }
+    }
+
+    public void Create(Scenario scenario)
+    {
+        ValidateId(scenario.Id);
+        lock (_lock)
+        {
+            var path = PathFor(scenario.Id);
+            if (File.Exists(path))
+                throw new ScenarioAlreadyExistsException(scenario.Id);
+            WriteFile(path, scenario);
+        }
+    }
+
+    public void Update(Scenario scenario)
+    {
+        ValidateId(scenario.Id);
+        lock (_lock)
+        {
+            var path = PathFor(scenario.Id);
+            if (!File.Exists(path))
+                throw new ScenarioNotFoundException(scenario.Id);
+            WriteFile(path, scenario);
+        }
+    }
+
+    public bool Delete(string id)
+    {
+        ValidateId(id);
+        lock (_lock)
+        {
+            var path = PathFor(id);
+            if (!File.Exists(path)) return false;
+            File.Delete(path);
+            return true;
+        }
+    }
+
+    private string PathFor(string id) => Path.Combine(_scenariosPath, $"{id}.json");
+
+    private static Scenario? ReadFile(string path)
+    {
+        using var stream = File.OpenRead(path);
+        return JsonSerializer.Deserialize<Scenario>(stream, JsonOptions);
+    }
+
+    private static void WriteFile(string path, Scenario scenario)
+    {
+        using var stream = File.Create(path);
+        JsonSerializer.Serialize(stream, scenario, JsonOptions);
+    }
+
+    private static void ValidateId(string id)
+    {
+        if (string.IsNullOrEmpty(id) || !IdPattern.IsMatch(id))
+            throw new InvalidScenarioIdException(id);
+    }
+
+    [GeneratedRegex("^[a-zA-Z0-9._-]{1,64}$", RegexOptions.CultureInvariant)]
+    private static partial Regex ScenarioIdRegex();
+}

--- a/Sources/Stockflow.Webserver/Scenarios/IScenarioRepository.cs
+++ b/Sources/Stockflow.Webserver/Scenarios/IScenarioRepository.cs
@@ -1,0 +1,19 @@
+namespace Stockflow.Webserver.Scenarios;
+
+public interface IScenarioRepository
+{
+    IEnumerable<ScenarioSummary> List();
+    Scenario?                    Get(string id);
+    void                         Create(Scenario scenario);
+    void                         Update(Scenario scenario);
+    bool                         Delete(string id);
+}
+
+public sealed class ScenarioNotFoundException(string id)
+    : Exception($"Scenario '{id}' not found");
+
+public sealed class ScenarioAlreadyExistsException(string id)
+    : Exception($"Scenario '{id}' already exists");
+
+public sealed class InvalidScenarioIdException(string id)
+    : Exception($"Scenario id '{id}' is invalid (allowed: a-z A-Z 0-9 . _ - up to 64 chars)");

--- a/Sources/Stockflow.Webserver/Scenarios/Scenario.cs
+++ b/Sources/Stockflow.Webserver/Scenarios/Scenario.cs
@@ -1,0 +1,43 @@
+namespace Stockflow.Webserver.Scenarios;
+
+/// <summary>
+/// Schema scenario file-based, mirror del formato §6.1 di ARCHITECTURE_StockFlow_v0.3.
+/// I campi non ancora supportati dalla simulazione (Budget, SkuCatalog, OrderProfile,
+/// Objectives, AvailableComponents, Duration) sono pass-through: persistiti ma
+/// ignorati dal loader con warning a log.
+/// </summary>
+public sealed record Scenario
+{
+    public required string Id          { get; init; }
+    public required string Name        { get; init; }
+    public          string? Description { get; init; }
+
+    public GridSize?           GridSize            { get; init; }
+    public int?                Budget              { get; init; }
+    public IReadOnlyList<string>? AvailableComponents { get; init; }
+    public IReadOnlyList<PreplacedComponent>? PreplacedComponents { get; init; }
+    public SkuCatalog?         SkuCatalog          { get; init; }
+    public OrderProfile?       OrderProfile        { get; init; }
+    public IReadOnlyDictionary<string, Objective>? Objectives { get; init; }
+    public int?                Duration            { get; init; }
+}
+
+public sealed record GridSize(int Width, int Height);
+
+public sealed record PreplacedComponent(string Type, int[] Position, string Direction);
+
+public sealed record SkuCatalog(int Count, IReadOnlyDictionary<string, SkuClass> Classes);
+
+public sealed record SkuClass(int Percentage, string AccessFrequency);
+
+public sealed record OrderProfile(
+    int            BaseRate,
+    int            PeakRate,
+    int            PeakStartTime,
+    int            PeakDuration,
+    LinesPerOrder? LinesPerOrder,
+    int            Deadline);
+
+public sealed record LinesPerOrder(int Min, int Max);
+
+public sealed record Objective(string Type, double? Value = null);

--- a/Sources/Stockflow.Webserver/Scenarios/ScenarioSummary.cs
+++ b/Sources/Stockflow.Webserver/Scenarios/ScenarioSummary.cs
@@ -1,0 +1,3 @@
+namespace Stockflow.Webserver.Scenarios;
+
+public sealed record ScenarioSummary(string Id, string Name, string? Description);

--- a/Sources/Stockflow.Webserver/Serialization/DirectionParser.cs
+++ b/Sources/Stockflow.Webserver/Serialization/DirectionParser.cs
@@ -1,0 +1,19 @@
+using SimDirection = Stockflow.Simulation.Component.Direction;
+
+namespace Stockflow.Webserver.Serialization;
+
+/// <summary>
+/// Parsing case-insensitive di direzioni cardinali, condiviso tra
+/// <c>SimulationController</c> (ingressi PascalCase dal client) e
+/// <c>SessionController</c> (ingressi lowercase dai file scenario §6.1).
+/// </summary>
+public static class DirectionParser
+{
+    public static SimDirection Parse(string? s) => (s ?? string.Empty).ToLowerInvariant() switch
+    {
+        "east"  => SimDirection.East,
+        "south" => SimDirection.South,
+        "west"  => SimDirection.West,
+        _       => SimDirection.North,
+    };
+}

--- a/Sources/Stockflow.Webserver/Sessions/ISessionManager.cs
+++ b/Sources/Stockflow.Webserver/Sessions/ISessionManager.cs
@@ -1,0 +1,20 @@
+namespace Stockflow.Webserver.Sessions;
+
+/// <summary>
+/// F1A: modello a singola sessione attiva. Il SimulationEngine resta un singleton
+/// globale, qui teniamo solo i metadati ciclo-vita della sessione corrente.
+/// Multi-session è scope F2.
+/// </summary>
+public interface ISessionManager
+{
+    SessionInfo? Current { get; }
+    SessionInfo  Start();
+    bool         Terminate(Guid id);
+    bool         TryAttachScenario(Guid id, string scenarioId);
+}
+
+public sealed class SessionAlreadyActiveException(Guid currentId)
+    : Exception($"A session ({currentId}) is already running. Terminate it before starting a new one.")
+{
+    public Guid CurrentId { get; } = currentId;
+}

--- a/Sources/Stockflow.Webserver/Sessions/SessionInfo.cs
+++ b/Sources/Stockflow.Webserver/Sessions/SessionInfo.cs
@@ -1,0 +1,9 @@
+namespace Stockflow.Webserver.Sessions;
+
+public sealed record SessionInfo(
+    Guid          Id,
+    SessionStatus Status,
+    DateTime      StartedAt,
+    DateTime?     EndedAt,
+    string?       ScenarioId,
+    float         SimulationTime);

--- a/Sources/Stockflow.Webserver/Sessions/SessionManager.cs
+++ b/Sources/Stockflow.Webserver/Sessions/SessionManager.cs
@@ -1,0 +1,70 @@
+using Stockflow.Simulation.Core;
+
+namespace Stockflow.Webserver.Sessions;
+
+public sealed class SessionManager(SimulationEngine engine) : ISessionManager
+{
+    private readonly object _lock = new();
+
+    private Guid?         _id;
+    private SessionStatus _status;
+    private DateTime      _startedAt;
+    private DateTime?     _endedAt;
+    private string?       _scenarioId;
+
+    public SessionInfo? Current
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _id is null ? null : BuildInfo();
+            }
+        }
+    }
+
+    public SessionInfo Start()
+    {
+        lock (_lock)
+        {
+            if (_id is not null && _status == SessionStatus.Running)
+                throw new SessionAlreadyActiveException(_id.Value);
+
+            _id         = Guid.NewGuid();
+            _status     = SessionStatus.Running;
+            _startedAt  = DateTime.UtcNow;
+            _endedAt    = null;
+            _scenarioId = null;
+            return BuildInfo();
+        }
+    }
+
+    public bool Terminate(Guid id)
+    {
+        lock (_lock)
+        {
+            if (_id != id || _status != SessionStatus.Running) return false;
+            _status  = SessionStatus.Terminated;
+            _endedAt = DateTime.UtcNow;
+            return true;
+        }
+    }
+
+    public bool TryAttachScenario(Guid id, string scenarioId)
+    {
+        lock (_lock)
+        {
+            if (_id != id || _status != SessionStatus.Running) return false;
+            _scenarioId = scenarioId;
+            return true;
+        }
+    }
+
+    private SessionInfo BuildInfo() => new(
+        Id:             _id!.Value,
+        Status:         _status,
+        StartedAt:      _startedAt,
+        EndedAt:        _endedAt,
+        ScenarioId:     _scenarioId,
+        SimulationTime: engine.SimulationTime);
+}

--- a/Sources/Stockflow.Webserver/Sessions/SessionStatus.cs
+++ b/Sources/Stockflow.Webserver/Sessions/SessionStatus.cs
@@ -1,0 +1,7 @@
+namespace Stockflow.Webserver.Sessions;
+
+public enum SessionStatus
+{
+    Running,
+    Terminated,
+}

--- a/Sources/Stockflow.Webserver/appsettings.json
+++ b/Sources/Stockflow.Webserver/appsettings.json
@@ -13,6 +13,7 @@
     "TickRate": 10,
     "GridWidth": 50,
     "GridLength": 50,
-    "GridFloors": 1
+    "GridFloors": 1,
+    "ScenariosPath": "Scenarios"
   }
 }


### PR DESCRIPTION
Closes #36.

Introduce le REST API per scenari e sessioni come da ARCHITECTURE §4.5 + §6, con il relativo supporto UI nella console Angular.

## Backend (Stockflow.Webserver, Stockflow.Simulation)

- `GET/POST/PUT/DELETE /api/scenarios` — CRUD file-based su `ContentRoot/Scenarios/` (path configurabile via `ServerConfig.ScenariosPath`), validazione id (`^[a-zA-Z0-9._-]{1,64}$`) per prevenire path traversal, mapping eccezioni → 400/404/409.
- `POST/GET/DELETE /api/sessions` — modello a singola sessione attiva (id, status `Running`/`Terminated`, startedAt, endedAt, scenarioId, simulationTime). 409 se si fa POST con sessione già Running.
- `POST /api/sessions/{id}/scenario/load` — applica gridSize + preplacedComponents allo `SimulationEngine` via un nuovo `LoadScenarioCommand` enqueueato sul tick loop (atomico). Accetta i wire-kind canonici (`package_generator`, `package_exit`, `conveyor_oneway`, `conveyor_turn`) oltre agli alias §6.1 (`conveyor_straight`, `conveyor_curve`). I campi non ancora supportati dalla simulazione (budget, skuCatalog, orderProfile, objectives, availableComponents, duration) loggano warning.
- `JsonStringEnumConverter` globale così `status` serializza come stringa.
- `DirectionParser` estratto e riusato (case-insensitive).

## Console Angular (Stockflow.Console)

- Servizi `ScenariosService` (CRUD) e `SessionsService` (start/terminate/loadScenario, signal `currentSession`).
- Topbar: id sessione dinamico + bottoni `START`/`STOP`/`SCENARIOS` (sostituiscono il segnaposto `#A4B21`).
- Modale `ScenariosPanel` per browse + load + delete + **SAVE CURRENT** (snapshot del grid e dei componenti piazzati come nuovo scenario; le proprietà configurabili dei componenti non sono incluse perché il formato §6.1 non le prevede).
- `REST_BASE`/`WS_URL` centralizzati in `core/config.ts`.

## Test

- 12 nuovi xUnit (`LoadScenarioCommandTests`): reset grid/components/entities, preservazione TimeScale, preplaced ok, dimensioni invalide, out-of-bounds, diff `GetStateDelta` post-reset (no ID collision), liberazione celle.
- 12 nuovi Vitest (`scenarios.service.spec.ts`, `sessions.service.spec.ts`): ogni metodo CRUD/lifecycle, propagazione 404/409, sync signal `currentSession`.

Tutti i test passano (81 .NET, 12 Angular). Il pre-esistente `app.spec.ts → should render title` resta rosso da `7ee4489` (#13) — fuori scope di questa PR.

## Verifica E2E

```bash
# crea scenario
curl -X POST http://localhost:9601/api/scenarios -H 'Content-Type: application/json' \
  -d '{"id":"smoke","name":"Smoke","gridSize":{"width":10,"height":10},
       "preplacedComponents":[{"type":"package_generator","position":[0,0],"direction":"east"}]}'

# avvia sessione e carica scenario
SESS=$(curl -s -X POST http://localhost:9601/api/sessions | jq -r .id)
curl -X POST http://localhost:9601/api/sessions/$SESS/scenario/load \
  -H 'Content-Type: application/json' -d '{"scenarioId":"smoke"}'

# verifica reset engine
curl http://localhost:9601/api/sim/state    # gridWidth=10, 1 componente
```

Round-trip UI: nella scenarios-panel `SAVE CURRENT` snapshotta lo stato corrente, poi `LOAD` sullo stesso scenario lo riapplica all'engine.

## Out of scope (pianificato F1A/F1B successivi)

- Endpoint metrics/orders di sessione (§4.5)
- Editor UI per Create/Update di scenari complessi (campi sku/order/objectives)
- Persistenza DB di `SessionRecord` (Stockflow.Persistence è ancora stub)
- Salvataggio delle proprietà configurabili dei componenti (richiede estensione del formato §6.1 di preplacedComponents)

---

🤖 Generated with [Claude Code](https://claude.ai/code)