### PR TITLE
feat(simulation): MergeLogic — conveyor merge 2→1 (issue #23)

### DIFF
--- a/Docs/superpowers/plans/2026-05-04-mergelogic.md
+++ b/Docs/superpowers/plans/2026-05-04-mergelogic.md
@@ -1,0 +1,848 @@
+# MergeLogic Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implementare il componente `MergeLogic` (2 ingressi, 1 uscita) con logica alternata/prioritaria e configurazione runtime delle porte via REST.
+
+**Architecture:** `MergeLogic` segue il pattern slot-singolo di `OneWayConveyor`/`ConveyorTurn`. La logica merge è gestita da `_activePort` (porta attualmente aperta) con anti-starvation tramite `_stallTicks`. `SetFacing` ricostruisce le porte e viene invocato dal `SimulationEngine` durante `ConfigureComponent` con successivo `AutoConnect`.
+
+**Tech Stack:** .NET 10, C# 13, xUnit, ASP.NET Core Minimal API.
+
+---
+
+## File map
+
+| File | Operazione |
+|---|---|
+| `Sources/Stockflow.Simulation/Component/MergeMode.cs` | Crea — enum `Alternating`/`Priority` |
+| `Sources/Stockflow.Simulation/Component/ComponentType.cs` | Modifica — aggiunge `MergeLogic` |
+| `Sources/Stockflow.Simulation/Component/MergeLogic.cs` | Crea — componente principale |
+| `Sources/Stockflow.Simulation/Commands/PlaceComponentCommand.cs` | Modifica — aggiunge `PlaceMergeLogicCommand` |
+| `Sources/Stockflow.Simulation/Core/SimulationEngine.cs` | Modifica — factory + `ConfigureComponent` branch |
+| `Sources/Stockflow.Protocol/Messages/SharedTypes.cs` | Modifica — aggiunge `ComponentKinds.MergeLogic` |
+| `Sources/Stockflow.Webserver/Controllers/SimulationController.cs` | Modifica — case `merge` + param `Mode` |
+| `Sources/Stockflow.Webserver/Serialization/ComponentSerializer.cs` | Modifica — `KindString` + `BuildProperties` |
+| `Sources/Stockflow.Console/src/app/core/mock/sim-mock.ts` | Modifica — `live: true` per `merge` |
+| `Sources/Stockflow.Tests.Simulation/MergeLogicTests.cs` | Crea — unit tests |
+
+---
+
+## Task 1: Tipi fondamentali — MergeMode + ComponentType
+
+**Files:**
+- Create: `Sources/Stockflow.Simulation/Component/MergeMode.cs`
+- Modify: `Sources/Stockflow.Simulation/Component/ComponentType.cs`
+
+- [ ] **Step 1: Crea MergeMode.cs**
+
+```csharp
+// Sources/Stockflow.Simulation/Component/MergeMode.cs
+namespace Stockflow.Simulation.Component;
+
+public enum MergeMode { Alternating, Priority }
+```
+
+- [ ] **Step 2: Aggiungi MergeLogic a ComponentType**
+
+Apri `Sources/Stockflow.Simulation/Component/ComponentType.cs`. Aggiungi `MergeLogic` alla fine dell'enum:
+
+```csharp
+namespace Stockflow.Simulation.Component;
+
+public enum ComponentType
+{
+    OneWayConveyor,
+    ConveyorTurn,
+    PackageGenerator,
+    PackageExit,
+    MergeLogic,
+}
+```
+
+- [ ] **Step 3: Verifica build**
+
+```
+dotnet build Sources/Stockflow.Simulation/
+```
+Expected: Build succeeded, 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```
+git add Sources/Stockflow.Simulation/Component/MergeMode.cs
+git add Sources/Stockflow.Simulation/Component/ComponentType.cs
+git commit -m "feat(simulation): aggiunge MergeMode enum e ComponentType.MergeLogic"
+```
+
+---
+
+## Task 2: MergeLogic — TryAccept e Tick
+
+**Files:**
+- Create: `Sources/Stockflow.Simulation/Component/MergeLogic.cs`
+- Create: `Sources/Stockflow.Tests.Simulation/MergeLogicTests.cs`
+
+### Ciclo TDD 1: gate di base (slot + porta)
+
+- [ ] **Step 1: Scrivi i primi 3 test (file nuovo)**
+
+```csharp
+// Sources/Stockflow.Tests.Simulation/MergeLogicTests.cs
+using Stockflow.Simulation.Component;
+using Stockflow.Simulation.Entity;
+using Stockflow.Simulation.Grid;
+using Stockflow.Simulation.Routing;
+
+namespace Stockflow.Tests.Simulation;
+
+public class MergeLogicTests
+{
+    private static MergeLogic MakeMerge(
+        MergeMode    mode  = MergeMode.Alternating,
+        RoutingGraph? graph = null)
+        => new(1, new GridCoord(0, 0), Direction.North, mode, 1f,
+               graph ?? new RoutingGraph());
+
+    [Fact]
+    public void TryAccept_EmptySlot_In0_Accepts()
+    {
+        var merge  = MakeMerge();
+        var entity = new EntityManager().Spawn("A", 1f, 1f, 0f, merge, new PortId(0));
+
+        Assert.True(merge.TryAccept(entity, new PortId(0)));
+        Assert.Same(merge, entity.CurrentComponent);
+        Assert.Equal(0f, entity.Progress);
+    }
+
+    [Fact]
+    public void TryAccept_EmptySlot_In1_Rejected_Initially()
+    {
+        var merge  = MakeMerge();
+        var entity = new EntityManager().Spawn("A", 1f, 1f, 0f, merge, new PortId(1));
+
+        Assert.False(merge.TryAccept(entity, new PortId(1)));
+        Assert.Null(merge.Occupant);
+    }
+
+    [Fact]
+    public void TryAccept_OccupiedSlot_ReturnsFalse()
+    {
+        var merge = MakeMerge();
+        var mgr   = new EntityManager();
+        var e1    = mgr.Spawn("A", 1f, 1f, 0f, merge, new PortId(0));
+        var e2    = mgr.Spawn("B", 1f, 1f, 0f, merge, new PortId(0));
+        merge.TryAccept(e1, new PortId(0));
+
+        Assert.False(merge.TryAccept(e2, new PortId(0)));
+    }
+}
+```
+
+- [ ] **Step 2: Verifica che i test non compilino (classe MergeLogic non esiste)**
+
+```
+dotnet test Sources/Stockflow.Tests.Simulation/ --no-build 2>&1 | head -5
+```
+Expected: build error "The type or namespace name 'MergeLogic' could not be found".
+
+- [ ] **Step 3: Crea MergeLogic.cs — scheletro completo**
+
+```csharp
+// Sources/Stockflow.Simulation/Component/MergeLogic.cs
+using Stockflow.Simulation.Entity;
+using Stockflow.Simulation.Grid;
+using Stockflow.Simulation.Modules;
+using Stockflow.Simulation.Routing;
+
+namespace Stockflow.Simulation.Component;
+
+public class MergeLogic : ISimComponent
+{
+    public  int                             Id       { get; }
+    public  GridCoord                       Position { get; }
+    public  Direction                       Facing   { get; private set; }
+    public  ComponentType                   Type     => ComponentType.MergeLogic;
+    public  IReadOnlyList<IComponentModule> Modules  { get; }
+    public  SimEntity?                      Occupant { get; private set; }
+    public  IReadOnlyList<Port>             Ports    => _ports;
+    public  float                           Speed    { get; set; }
+    public  MergeMode                       Mode     { get; set; }
+    public  RoutingGraph                    Graph    { get; }
+
+    private Port   _inPort0;
+    private Port   _inPort1;
+    private Port   _outPort;
+    private Port[] _ports = null!;
+    private PortId _activePort;
+    private int    _stallTicks;
+    private const int StallThreshold = 30;
+
+    public MergeLogic(int id, GridCoord position, Direction facing, MergeMode mode, float speed,
+                      RoutingGraph graph, IReadOnlyList<IComponentModule>? modules = null)
+    {
+        Id          = id;
+        Position    = position;
+        Mode        = mode;
+        Speed       = speed;
+        Graph       = graph;
+        Modules     = modules ?? [];
+        _activePort = new PortId(0);
+        SetFacing(facing);
+    }
+
+    public void SetFacing(Direction facing)
+    {
+        Facing   = facing;
+        _inPort0 = new(new PortId(0), Position + facing.Opposite().ToOffset(),  PortDirection.In);
+        _inPort1 = new(new PortId(1), Position + facing.RotateCCW().ToOffset(), PortDirection.In);
+        _outPort = new(new PortId(2), Position + facing.ToOffset(),             PortDirection.Out);
+        _ports   = [_inPort0, _inPort1, _outPort];
+    }
+
+    public void Tick(float deltaTime)
+    {
+        if (Occupant != null)
+        {
+            if (Occupant.Progress < 1.0f)
+            {
+                Occupant.Progress += Speed * deltaTime;
+            }
+            else
+            {
+                var next = Graph.GetNext(this, _outPort.Id);
+                if (next != null && next.Value.To.TryAccept(Occupant, next.Value.ToPort))
+                {
+                    foreach (var module in Modules)
+                        module.OnEntityExit(Occupant);
+                    Occupant = null;
+                }
+            }
+        }
+        else
+        {
+            _stallTicks++;
+            if (_stallTicks >= StallThreshold)
+            {
+                _activePort = _activePort == new PortId(0) ? new PortId(1) : new PortId(0);
+                _stallTicks = 0;
+            }
+        }
+    }
+
+    public bool TryAccept(SimEntity entity, PortId fromPort)
+    {
+        if (Occupant != null) return false;
+        if (fromPort != _activePort) return false;
+
+        Occupant                = entity;
+        entity.CurrentComponent = this;
+        entity.CurrentPort      = fromPort;
+        entity.Progress         = 0.0f;
+        _stallTicks             = 0;
+
+        if (Mode == MergeMode.Alternating)
+            _activePort = _activePort == new PortId(0) ? new PortId(1) : new PortId(0);
+        else
+            _activePort = new PortId(0);
+
+        foreach (var module in Modules)
+            module.OnEntityEnter(entity);
+
+        return true;
+    }
+}
+```
+
+- [ ] **Step 4: Esegui i primi 3 test**
+
+```
+dotnet test Sources/Stockflow.Tests.Simulation/ --filter "FullyQualifiedName~MergeLogicTests.TryAccept"
+```
+Expected: 3 passed.
+
+### Ciclo TDD 2: logica alternata
+
+- [ ] **Step 5: Aggiungi test Alternating a MergeLogicTests.cs**
+
+Aggiungi questi due test alla classe `MergeLogicTests`:
+
+```csharp
+[Fact]
+public void Alternating_AfterIn0_ActiveSwitchesToIn1()
+{
+    var graph = new RoutingGraph();
+    var merge = MakeMerge(MergeMode.Alternating, graph);
+    var mgr   = new EntityManager();
+    var exit  = new PackageExit(2, new GridCoord(0, -1), Direction.North, mgr);
+    graph.Connect(merge, new PortId(2), exit, new PortId(0));
+
+    var e1 = mgr.Spawn("A", 1f, 1f, 0f, merge, new PortId(0));
+    merge.TryAccept(e1, new PortId(0));
+    merge.Tick(1f); merge.Tick(0f); exit.Tick(0f); // drain
+
+    var e2 = mgr.Spawn("B", 1f, 1f, 0f, merge, new PortId(0));
+    Assert.False(merge.TryAccept(e2, new PortId(0))); // In0 chiusa
+    var e3 = mgr.Spawn("C", 1f, 1f, 0f, merge, new PortId(1));
+    Assert.True(merge.TryAccept(e3, new PortId(1)));  // In1 aperta
+}
+
+[Fact]
+public void Alternating_AfterIn1_ActiveSwitchesToIn0()
+{
+    var graph = new RoutingGraph();
+    var merge = MakeMerge(MergeMode.Alternating, graph);
+    var mgr   = new EntityManager();
+    var exit  = new PackageExit(2, new GridCoord(0, -1), Direction.North, mgr);
+    graph.Connect(merge, new PortId(2), exit, new PortId(0));
+
+    // 1° round: In0 → attiva diventa In1
+    var e1 = mgr.Spawn("A", 1f, 1f, 0f, merge, new PortId(0));
+    merge.TryAccept(e1, new PortId(0));
+    merge.Tick(1f); merge.Tick(0f); exit.Tick(0f);
+
+    // 2° round: In1 → attiva diventa In0
+    var e2 = mgr.Spawn("B", 1f, 1f, 0f, merge, new PortId(1));
+    merge.TryAccept(e2, new PortId(1));
+    merge.Tick(1f); merge.Tick(0f); exit.Tick(0f);
+
+    // Ora In0 deve essere attiva di nuovo
+    var e3 = mgr.Spawn("C", 1f, 1f, 0f, merge, new PortId(1));
+    Assert.False(merge.TryAccept(e3, new PortId(1))); // In1 chiusa
+    var e4 = mgr.Spawn("D", 1f, 1f, 0f, merge, new PortId(0));
+    Assert.True(merge.TryAccept(e4, new PortId(0)));  // In0 aperta
+}
+```
+
+- [ ] **Step 6: Esegui i test Alternating**
+
+```
+dotnet test Sources/Stockflow.Tests.Simulation/ --filter "FullyQualifiedName~MergeLogicTests.Alternating"
+```
+Expected: 2 passed. (La logica è già nella classe; se fallisce, ricontrolla la logica `_activePort` in `TryAccept`.)
+
+### Ciclo TDD 3: logica prioritaria
+
+- [ ] **Step 7: Aggiungi test Priority a MergeLogicTests.cs**
+
+```csharp
+[Fact]
+public void Priority_AfterIn0_ActiveStaysIn0()
+{
+    var graph = new RoutingGraph();
+    var merge = MakeMerge(MergeMode.Priority, graph);
+    var mgr   = new EntityManager();
+    var exit  = new PackageExit(2, new GridCoord(0, -1), Direction.North, mgr);
+    graph.Connect(merge, new PortId(2), exit, new PortId(0));
+
+    var e1 = mgr.Spawn("A", 1f, 1f, 0f, merge, new PortId(0));
+    merge.TryAccept(e1, new PortId(0));
+    merge.Tick(1f); merge.Tick(0f); exit.Tick(0f);
+
+    var e2 = mgr.Spawn("B", 1f, 1f, 0f, merge, new PortId(1));
+    Assert.False(merge.TryAccept(e2, new PortId(1))); // In1 sempre chiusa
+    var e3 = mgr.Spawn("C", 1f, 1f, 0f, merge, new PortId(0));
+    Assert.True(merge.TryAccept(e3, new PortId(0)));  // In0 rimane attiva
+}
+
+[Fact]
+public void Priority_StallThreshold_SwitchesToIn1()
+{
+    var merge = MakeMerge(MergeMode.Priority);
+    var mgr   = new EntityManager();
+
+    for (int i = 0; i < 30; i++) merge.Tick(0f);
+
+    var entity = mgr.Spawn("A", 1f, 1f, 0f, merge, new PortId(1));
+    Assert.True(merge.TryAccept(entity, new PortId(1)));
+}
+
+[Fact]
+public void Priority_AfterIn1Accepts_BackToIn0()
+{
+    var graph = new RoutingGraph();
+    var merge = MakeMerge(MergeMode.Priority, graph);
+    var mgr   = new EntityManager();
+    var exit  = new PackageExit(2, new GridCoord(0, -1), Direction.North, mgr);
+    graph.Connect(merge, new PortId(2), exit, new PortId(0));
+
+    for (int i = 0; i < 30; i++) merge.Tick(0f); // starvation → In1 aperta
+
+    var e1 = mgr.Spawn("A", 1f, 1f, 0f, merge, new PortId(1));
+    merge.TryAccept(e1, new PortId(1));
+    merge.Tick(1f); merge.Tick(0f); exit.Tick(0f);
+
+    // Torna a In0
+    var e2 = mgr.Spawn("B", 1f, 1f, 0f, merge, new PortId(1));
+    Assert.False(merge.TryAccept(e2, new PortId(1)));
+    var e3 = mgr.Spawn("C", 1f, 1f, 0f, merge, new PortId(0));
+    Assert.True(merge.TryAccept(e3, new PortId(0)));
+}
+```
+
+- [ ] **Step 8: Esegui i test Priority**
+
+```
+dotnet test Sources/Stockflow.Tests.Simulation/ --filter "FullyQualifiedName~MergeLogicTests.Priority"
+```
+Expected: 3 passed.
+
+### Ciclo TDD 4: Tick
+
+- [ ] **Step 9: Aggiungi test Tick a MergeLogicTests.cs**
+
+```csharp
+[Fact]
+public void Tick_ProgressAdvances()
+{
+    var merge  = MakeMerge();
+    var entity = new EntityManager().Spawn("A", 1f, 1f, 0f, merge, new PortId(0));
+    merge.TryAccept(entity, new PortId(0));
+
+    merge.Tick(0.5f);
+
+    Assert.Equal(0.5f, entity.Progress);
+}
+
+[Fact]
+public void Tick_EntityComplete_TransfersDownstream()
+{
+    var graph      = new RoutingGraph();
+    var merge      = MakeMerge(graph: graph);
+    var downstream = new OneWayConveyor(2, new GridCoord(0, -1), Direction.North, 1f, graph);
+    graph.Connect(merge, new PortId(2), downstream, new PortId(0));
+
+    var entity = new EntityManager().Spawn("A", 1f, 1f, 0f, merge, new PortId(0));
+    merge.TryAccept(entity, new PortId(0));
+    merge.Tick(1f);
+    merge.Tick(0f);
+
+    Assert.Null(merge.Occupant);
+    Assert.Same(downstream, entity.CurrentComponent);
+}
+
+[Fact]
+public void Tick_NoNext_EntityStays()
+{
+    var merge  = MakeMerge();
+    var entity = new EntityManager().Spawn("A", 1f, 1f, 0f, merge, new PortId(0));
+    merge.TryAccept(entity, new PortId(0));
+    merge.Tick(1f);
+    merge.Tick(0f);
+
+    Assert.Same(entity, merge.Occupant);
+}
+
+[Fact]
+public void StallTicks_ResetOnAccept()
+{
+    var graph = new RoutingGraph();
+    var merge = MakeMerge(MergeMode.Priority, graph);
+    var mgr   = new EntityManager();
+    var exit  = new PackageExit(2, new GridCoord(0, -1), Direction.North, mgr);
+    graph.Connect(merge, new PortId(2), exit, new PortId(0));
+
+    for (int i = 0; i < 15; i++) merge.Tick(0f); // _stallTicks = 15
+
+    var e1 = mgr.Spawn("A", 1f, 1f, 0f, merge, new PortId(0));
+    merge.TryAccept(e1, new PortId(0)); // reset _stallTicks a 0
+    merge.Tick(1f); merge.Tick(0f); exit.Tick(0f);
+
+    // 29 tick < soglia 30 — non deve ancora switchare
+    for (int i = 0; i < 29; i++) merge.Tick(0f);
+
+    var e2 = mgr.Spawn("B", 1f, 1f, 0f, merge, new PortId(1));
+    Assert.False(merge.TryAccept(e2, new PortId(1))); // In0 ancora attiva
+}
+```
+
+- [ ] **Step 10: Esegui tutti i test Tick**
+
+```
+dotnet test Sources/Stockflow.Tests.Simulation/ --filter "FullyQualifiedName~MergeLogicTests.Tick|FullyQualifiedName~MergeLogicTests.StallTicks"
+```
+Expected: 4 passed.
+
+- [ ] **Step 11: Esegui tutti i test della suite**
+
+```
+dotnet test Sources/Stockflow.Tests.Simulation/
+```
+Expected: tutti i test passano (inclusi i pre-esistenti).
+
+- [ ] **Step 12: Commit**
+
+```
+git add Sources/Stockflow.Simulation/Component/MergeLogic.cs
+git add Sources/Stockflow.Tests.Simulation/MergeLogicTests.cs
+git commit -m "feat(simulation): implementa MergeLogic con logica alternata e prioritaria"
+```
+
+---
+
+## Task 3: MergeLogic — test SetFacing
+
+**Files:**
+- Modify: `Sources/Stockflow.Tests.Simulation/MergeLogicTests.cs`
+
+- [ ] **Step 1: Aggiungi test SetFacing**
+
+Aggiungi a `MergeLogicTests`:
+
+```csharp
+[Fact]
+public void SetFacing_RebuildsPortPositions()
+{
+    // Position (0,0), default Facing = North
+    // Dopo SetFacing(East):
+    //   In0 (PortId 0): Position + West.ToOffset()  = (-1, 0)
+    //   In1 (PortId 1): Position + North.ToOffset() = ( 0,-1)  [East.RotateCCW() = North]
+    //   Out (PortId 2): Position + East.ToOffset()  = ( 1, 0)
+    var merge = MakeMerge();
+
+    merge.SetFacing(Direction.East);
+
+    Assert.Equal(Direction.East, merge.Facing);
+    Assert.Equal(3, merge.Ports.Count);
+
+    var in0 = merge.Ports.First(p => p.Id == new PortId(0));
+    var in1 = merge.Ports.First(p => p.Id == new PortId(1));
+    var @out = merge.Ports.First(p => p.Id == new PortId(2));
+
+    Assert.Equal(new GridCoord(-1,  0), in0.Position);
+    Assert.Equal(new GridCoord( 0, -1), in1.Position);
+    Assert.Equal(new GridCoord( 1,  0), @out.Position);
+    Assert.Equal(PortDirection.In,  in0.Direction);
+    Assert.Equal(PortDirection.In,  in1.Direction);
+    Assert.Equal(PortDirection.Out, @out.Direction);
+}
+```
+
+- [ ] **Step 2: Esegui il test**
+
+```
+dotnet test Sources/Stockflow.Tests.Simulation/ --filter "FullyQualifiedName~MergeLogicTests.SetFacing"
+```
+Expected: 1 passed. (`SetFacing` è già implementata nello scheletro del Task 2.)
+
+- [ ] **Step 3: Commit**
+
+```
+git add Sources/Stockflow.Tests.Simulation/MergeLogicTests.cs
+git commit -m "test(simulation): aggiunge SetFacing_RebuildsPortPositions per MergeLogic"
+```
+
+---
+
+## Task 4: PlaceMergeLogicCommand + SimulationEngine
+
+**Files:**
+- Modify: `Sources/Stockflow.Simulation/Commands/PlaceComponentCommand.cs`
+- Modify: `Sources/Stockflow.Simulation/Core/SimulationEngine.cs`
+
+- [ ] **Step 1: Aggiungi PlaceMergeLogicCommand a PlaceComponentCommand.cs**
+
+Apri `Sources/Stockflow.Simulation/Commands/PlaceComponentCommand.cs`. Aggiungi alla fine del file (prima della riga `RemoveComponentCommand`):
+
+```csharp
+public sealed record PlaceMergeLogicCommand(
+    GridCoord Position,
+    Direction Facing,
+    MergeMode Mode  = MergeMode.Alternating,
+    float     Speed = 1f
+) : ICommand;
+```
+
+Il file finale sarà:
+
+```csharp
+using Stockflow.Simulation.Component;
+using Stockflow.Simulation.Grid;
+
+namespace Stockflow.Simulation.Commands;
+
+public sealed record PlacePackageGeneratorCommand(
+    GridCoord Position,
+    Direction Facing,
+    float     SpawnRate = 1f,
+    string    Sku       = "PKG",
+    float     Weight    = 1f,
+    float     Size      = 1f
+) : ICommand;
+
+public sealed record PlacePackageExitCommand(
+    GridCoord Position,
+    Direction Facing
+) : ICommand;
+
+public sealed record PlaceOneWayConveyorCommand(
+    GridCoord Position,
+    Direction Facing,
+    float     Speed = 1f
+) : ICommand;
+
+public sealed record PlaceConveyorTurnCommand(
+    GridCoord Position,
+    Direction Facing,
+    TurnSide  Turn  = TurnSide.Right,
+    float     Speed = 1f
+) : ICommand;
+
+public sealed record PlaceMergeLogicCommand(
+    GridCoord Position,
+    Direction Facing,
+    MergeMode Mode  = MergeMode.Alternating,
+    float     Speed = 1f
+) : ICommand;
+
+public sealed record RemoveComponentCommand(int ComponentId) : ICommand;
+```
+
+- [ ] **Step 2: Registra factory in SimulationEngine**
+
+Apri `Sources/Stockflow.Simulation/Core/SimulationEngine.cs`. Nel costruttore, aggiungi alla fine del dizionario `_placementFactories` (prima della `}`):
+
+```csharp
+[typeof(PlaceMergeLogicCommand)] = (c, id) =>
+{
+    var x = (PlaceMergeLogicCommand)c;
+    return new MergeLogic(id, x.Position, x.Facing, x.Mode, x.Speed, Graph);
+},
+```
+
+- [ ] **Step 3: Aggiungi branch ConfigureComponent per MergeLogic**
+
+Nel metodo `ConfigureComponent` di `SimulationEngine.cs`, aggiungi prima del return finale:
+
+```csharp
+if (component is MergeLogic merge)
+{
+    if (cmd.Properties.TryGetValue("mode", out var m))
+        merge.Mode = m.Equals("priority", StringComparison.OrdinalIgnoreCase)
+                         ? MergeMode.Priority
+                         : MergeMode.Alternating;
+    if (cmd.Properties.TryGetValue("speed", out var sp) && float.TryParse(sp, out var speed) && speed > 0)
+        merge.Speed = speed;
+    if (cmd.Properties.TryGetValue("facing", out var f) &&
+        Enum.TryParse<Direction>(f, ignoreCase: true, out var newFacing))
+    {
+        Graph.DisconnectAll(merge);
+        merge.SetFacing(newFacing);
+        AutoConnect(merge);
+    }
+    return CommandResult.Ok();
+}
+```
+
+- [ ] **Step 4: Scrivi i test engine**
+
+Aggiungi alla fine di `Sources/Stockflow.Tests.Simulation/MergeLogicTests.cs`:
+
+```csharp
+// ── SimulationEngine integration ──────────────────────────────────────────
+
+[Fact]
+public void Engine_PlaceMergeLogic_AddsComponent()
+{
+    var engine = new Stockflow.Simulation.Core.SimulationEngine(10, 10, 1);
+    engine.ProcessCommand(new Stockflow.Simulation.Commands.PlaceMergeLogicCommand(
+        new GridCoord(5, 5), Direction.North));
+
+    Assert.Single(engine.State.Components);
+    Assert.IsType<MergeLogic>(engine.State.Components[0]);
+    Assert.Equal(ComponentType.MergeLogic, engine.State.Components[0].Type);
+}
+
+[Fact]
+public void Engine_ConfigureMerge_Mode_UpdatesMode()
+{
+    var engine = new Stockflow.Simulation.Core.SimulationEngine(10, 10, 1);
+    engine.ProcessCommand(new Stockflow.Simulation.Commands.PlaceMergeLogicCommand(
+        new GridCoord(5, 5), Direction.North, MergeMode.Alternating));
+    var merge = (MergeLogic)engine.State.Components[0];
+
+    engine.ProcessCommand(new Stockflow.Simulation.Commands.ConfigureComponentCommand(
+        merge.Id, new Dictionary<string, string> { ["mode"] = "priority" }));
+
+    Assert.Equal(MergeMode.Priority, merge.Mode);
+}
+
+[Fact]
+public void Engine_ConfigureMerge_Facing_UpdatesFacing()
+{
+    var engine = new Stockflow.Simulation.Core.SimulationEngine(10, 10, 1);
+    engine.ProcessCommand(new Stockflow.Simulation.Commands.PlaceMergeLogicCommand(
+        new GridCoord(5, 5), Direction.North));
+    var merge = (MergeLogic)engine.State.Components[0];
+
+    engine.ProcessCommand(new Stockflow.Simulation.Commands.ConfigureComponentCommand(
+        merge.Id, new Dictionary<string, string> { ["facing"] = "East" }));
+
+    Assert.Equal(Direction.East, merge.Facing);
+}
+```
+
+- [ ] **Step 5: Esegui i test engine**
+
+```
+dotnet test Sources/Stockflow.Tests.Simulation/ --filter "FullyQualifiedName~MergeLogicTests.Engine"
+```
+Expected: 3 passed.
+
+- [ ] **Step 6: Esegui l'intera suite**
+
+```
+dotnet test
+```
+Expected: tutti i test passano.
+
+- [ ] **Step 7: Commit**
+
+```
+git add Sources/Stockflow.Simulation/Commands/PlaceComponentCommand.cs
+git add Sources/Stockflow.Simulation/Core/SimulationEngine.cs
+git add Sources/Stockflow.Tests.Simulation/MergeLogicTests.cs
+git commit -m "feat(simulation): PlaceMergeLogicCommand + engine factory e ConfigureComponent"
+```
+
+---
+
+## Task 5: Webserver layer
+
+**Files:**
+- Modify: `Sources/Stockflow.Protocol/Messages/SharedTypes.cs`
+- Modify: `Sources/Stockflow.Webserver/Controllers/SimulationController.cs`
+- Modify: `Sources/Stockflow.Webserver/Serialization/ComponentSerializer.cs`
+- Modify: `Sources/Stockflow.Console/src/app/core/mock/sim-mock.ts`
+
+- [ ] **Step 1: Aggiungi ComponentKinds.MergeLogic in SharedTypes.cs**
+
+Apri `Sources/Stockflow.Protocol/Messages/SharedTypes.cs`. Aggiungi alla classe `ComponentKinds`:
+
+```csharp
+public static class ComponentKinds
+{
+    public const string OneWayConveyor   = "conveyor_oneway";
+    public const string ConveyorTurn     = "conveyor_turn";
+    public const string PackageGenerator = "package_generator";
+    public const string PackageExit      = "package_exit";
+    public const string MergeLogic       = "merge";
+}
+```
+
+- [ ] **Step 2: Aggiungi Mode a PlaceComponentRequest e case merge in SimulationController.cs**
+
+Apri `Sources/Stockflow.Webserver/Controllers/SimulationController.cs`.
+
+**2a.** Modifica il record `PlaceComponentRequest` aggiungendo `string? Mode = null`:
+
+```csharp
+public sealed record PlaceComponentRequest(
+    string  Kind,
+    int     GridX,
+    int     GridY,
+    string? Facing    = "North",
+    float?  SpawnRate = null,
+    string? Sku       = null,
+    float?  Weight    = null,
+    float?  Size      = null,
+    string? Turn      = null,
+    float?  Speed     = null,
+    string? Mode      = null);
+```
+
+**2b.** Nel metodo `PlaceComponent`, aggiungi il case `merge` nello switch (dopo `ComponentKinds.ConveyorTurn`):
+
+```csharp
+ComponentKinds.MergeLogic => new PlaceMergeLogicCommand(
+    pos,
+    dir,
+    req.Mode?.Equals("priority", StringComparison.OrdinalIgnoreCase) == true
+        ? MergeMode.Priority
+        : MergeMode.Alternating,
+    req.Speed ?? 1f),
+```
+
+Aggiungi anche il using necessario in cima al file se non presente:
+```csharp
+using Stockflow.Simulation.Component;
+```
+(È già presente perché usa `TurnSide`.)
+
+- [ ] **Step 3: Aggiorna ComponentSerializer**
+
+Apri `Sources/Stockflow.Webserver/Serialization/ComponentSerializer.cs`.
+
+**3a.** In `KindString`, aggiungi prima del catch-all `_`:
+
+```csharp
+SimComponentType.MergeLogic => ComponentKinds.MergeLogic,
+```
+
+**3b.** In `BuildProperties`, aggiungi prima del catch-all `_ => null`:
+
+```csharp
+MergeLogic m => new()
+{
+    ["mode"]  = m.Mode == MergeMode.Priority ? "priority" : "alternating",
+    ["speed"] = m.Speed.ToString("F3"),
+},
+```
+
+Aggiungi il using in cima se non presente:
+```csharp
+using Stockflow.Simulation.Commands;
+```
+(Non serve — MergeLogic e MergeMode sono in `Stockflow.Simulation.Component`, già importato.)
+
+- [ ] **Step 4: Attiva merge nella libreria componenti Angular**
+
+Apri `Sources/Stockflow.Console/src/app/core/mock/sim-mock.ts`. Cambia `live: false` in `live: true` per la voce `merge`:
+
+```typescript
+{ id: 'merge',  name: 'Merge',       sym: '┳', cost: 300,  hotkey: '3', kind: 'merge',           live: true  },
+```
+
+- [ ] **Step 5: Build completo**
+
+```
+dotnet build Stockflow.slnx
+```
+Expected: Build succeeded, 0 errors.
+
+- [ ] **Step 6: Esegui l'intera test suite**
+
+```
+dotnet test
+```
+Expected: tutti i test passano.
+
+- [ ] **Step 7: Commit**
+
+```
+git add Sources/Stockflow.Protocol/Messages/SharedTypes.cs
+git add Sources/Stockflow.Webserver/Controllers/SimulationController.cs
+git add Sources/Stockflow.Webserver/Serialization/ComponentSerializer.cs
+git add Sources/Stockflow.Console/src/app/core/mock/sim-mock.ts
+git commit -m "feat(webserver): espone MergeLogic via REST + abilita nel frontend"
+```
+
+---
+
+## Self-review checklist (già eseguita)
+
+| Requisito spec | Task che lo copre |
+|---|---|
+| 2 ingressi, 1 uscita (1×1) | Task 2 — porte In0/In1/Out |
+| Logica alternata | Task 2 — ciclo TDD 2 |
+| Logica prioritaria | Task 2 — ciclo TDD 3 |
+| Gestione conflitti (slot singolo) | Task 2 — `TryAccept_OccupiedSlot_ReturnsFalse` |
+| Buffer minimo (slot singolo) | Task 2 — `Occupant: SimEntity?` |
+| Anti-starvation | Task 2 — ciclo TDD 3 (`Priority_StallThreshold_SwitchesToIn1`) |
+| SetFacing ricostruisce porte | Task 3 — `SetFacing_RebuildsPortPositions` |
+| PlaceMergeLogicCommand | Task 4 — Step 1 |
+| SimulationEngine factory | Task 4 — Step 2 |
+| ConfigureComponent (mode/speed/facing) | Task 4 — Step 3 + test Engine_Configure* |
+| ComponentKinds.MergeLogic | Task 5 — Step 1 |
+| REST PlaceComponent case merge | Task 5 — Step 2 |
+| ComponentSerializer | Task 5 — Step 3 |
+| Frontend live: true | Task 5 — Step 4 |

--- a/Docs/superpowers/specs/2026-05-04-mergelogic-design.md
+++ b/Docs/superpowers/specs/2026-05-04-mergelogic-design.md
@@ -1,0 +1,120 @@
+# MergeLogic — Design Spec
+**Issue:** #23  
+**Milestone:** F1A — Core Gameplay  
+**Data:** 2026-05-04
+
+---
+
+## 1. Requisiti (da issue #23)
+
+- Componente 1×1 con 2 ingressi e 1 uscita
+- Logica configurabile: **alternata** o **prioritaria**
+- Gestione conflitti quando entrambi gli ingressi hanno un pacco disponibile
+- Buffer minimo interno: **slot singolo** (stesso modello di `OneWayConveyor`)
+
+---
+
+## 2. File da creare/modificare
+
+| File | Operazione |
+|---|---|
+| `Sources/Stockflow.Simulation/Component/MergeLogic.cs` | Nuovo |
+| `Sources/Stockflow.Simulation/Component/MergeMode.cs` | Nuovo |
+| `Sources/Stockflow.Simulation/Component/ComponentType.cs` | Aggiunta voce `MergeLogic` |
+| `Sources/Stockflow.Tests.Simulation/MergeLogicTests.cs` | Nuovo |
+
+---
+
+## 3. Struttura dati
+
+### 3.1 MergeMode
+
+```csharp
+public enum MergeMode { Alternating, Priority }
+```
+
+### 3.2 Porte (default Facing = North)
+
+| PortId | PortDirection | Posizione relativa | Ruolo |
+|---|---|---|---|
+| 0 | In | `Position + Facing.Opposite().ToOffset()` | Ingresso primario |
+| 1 | In | `Position + Facing.RotateCCW().ToOffset()` | Ingresso secondario |
+| 2 | Out | `Position + Facing.ToOffset()` | Uscita |
+
+L'ingresso primario (PortId 0) è il lato opposto al Facing, coerente con gli altri conveyor.  
+L'ingresso secondario (PortId 1) arriva dal lato sinistro rispetto al Facing.
+
+### 3.3 Campi interni
+
+```
+SimEntity?  Occupant        — entità in transito (progress 0→1)
+float       Speed           — velocità di transito
+MergeMode   Mode            — Alternating | Priority
+PortId      _activePort     — porta di ingresso attualmente aperta
+int         _stallTicks     — tick consecutivi con slot vuoto
+const int   StallThreshold  — soglia anti-starvation (costante privata = 30)
+```
+
+`_activePort` inizializzato a `PortId(0)` (ingresso primario).
+
+---
+
+## 4. Comportamento
+
+### 4.1 TryAccept(entity, fromPort)
+
+1. Se `Occupant != null` → restituisce `false` (slot occupato)
+2. Se `fromPort != _activePort` → restituisce `false` (porta chiusa dalla logica merge)
+3. Accetta l'entità: `Occupant = entity`, `Progress = 0`, `_stallTicks = 0`
+4. Aggiorna `_activePort`:
+   - **Alternating**: passa all'altra porta (`In0 ↔ In1`)
+   - **Priority**: se `_activePort` era `In1` (aperto per starvation), torna a `In0`; altrimenti rimane su `In0`
+
+### 4.2 Tick(deltaTime)
+
+```
+if Occupant != null:
+    if Progress < 1.0:
+        Progress += Speed * deltaTime
+    else:
+        next = Graph.GetNext(this, OutPort.Id)
+        if next != null && next.TryAccept(Occupant, next.ToPort):
+            fire OnEntityExit modules
+            Occupant = null
+else:
+    _stallTicks++
+    if _stallTicks >= StallThreshold:
+        switch _activePort (In0 ↔ In1)
+        _stallTicks = 0
+```
+
+### 4.3 Conflict resolution
+
+Se due upstream conveyors chiamano `TryAccept` nello stesso tick, il primo vincerà (lo slot si riempie), il secondo riceverà `false` e rimarrà bloccato sul proprio conveyor. Gestione implicita dal modello a slot singolo, nessuna logica extra necessaria.
+
+---
+
+## 5. Test plan
+
+| Test | Comportamento verificato |
+|---|---|
+| `TryAccept_EmptySlot_In0_Accepts` | Porta attiva di default è In0 |
+| `TryAccept_EmptySlot_In1_Rejected_Initially` | In1 rifiutata quando `_activePort = In0` |
+| `TryAccept_OccupiedSlot_ReturnsFalse` | Slot pieno → sempre false indipendentemente dalla porta |
+| `Alternating_AfterIn0_ActiveSwitchesToIn1` | Dopo accettare da In0, In1 diventa attiva |
+| `Alternating_AfterIn1_ActiveSwitchesToIn0` | Round-robin completo |
+| `Priority_AfterIn0_ActiveStaysIn0` | In0 rimane sempre prioritaria dopo accettazione |
+| `Priority_StallThreshold_SwitchesToIn1` | Dopo `StallThreshold` tick vuoti, In1 si apre |
+| `Priority_AfterIn1Accepts_BackToIn0` | Dopo accettare da In1, `_activePort` torna a In0 |
+| `Tick_ProgressAdvances` | `Progress += Speed * deltaTime` |
+| `Tick_EntityComplete_TransfersDownstream` | Trasferimento corretto al componente a valle |
+| `Tick_NoNext_EntityStays` | Nessun downstream → entità rimane (jam) |
+| `StallTicks_ResetOnAccept` | `_stallTicks` azzerato ad ogni accettazione |
+
+---
+
+## 6. Vincoli architetturali
+
+- `Stockflow.Simulation` deve rimanere **zero dipendenze NuGet** — nessuna dipendenza esterna introdotta
+- `MergeLogic` segue esattamente lo stesso pattern di `OneWayConveyor` e `ConveyorTurn`
+- Il campo `Occupant` esposto da `ISimComponent` rappresenta l'entità in transito (progress 0→1), non un buffer

--- a/Docs/superpowers/specs/2026-05-04-mergelogic-design.md
+++ b/Docs/superpowers/specs/2026-05-04-mergelogic-design.md
@@ -21,6 +21,11 @@
 | `Sources/Stockflow.Simulation/Component/MergeLogic.cs` | Nuovo |
 | `Sources/Stockflow.Simulation/Component/MergeMode.cs` | Nuovo |
 | `Sources/Stockflow.Simulation/Component/ComponentType.cs` | Aggiunta voce `MergeLogic` |
+| `Sources/Stockflow.Simulation/Commands/PlaceComponentCommand.cs` | Aggiunta `PlaceMergeLogicCommand` |
+| `Sources/Stockflow.Simulation/Core/SimulationEngine.cs` | Factory + branch `ConfigureComponent` |
+| `Sources/Stockflow.Protocol/Messages/SharedTypes.cs` | Aggiunta `ComponentKinds.MergeLogic` |
+| `Sources/Stockflow.Webserver/Controllers/SimulationController.cs` | Case `merge` in `PlaceComponent` + `Mode` in request |
+| `Sources/Stockflow.Webserver/Serialization/ComponentSerializer.cs` | `KindString` + `BuildProperties` per MergeLogic |
 | `Sources/Stockflow.Tests.Simulation/MergeLogicTests.cs` | Nuovo |
 
 ---
@@ -94,7 +99,7 @@ Se due upstream conveyors chiamano `TryAccept` nello stesso tick, il primo vince
 
 ---
 
-## 5. Test plan
+## 5. Test plan (simulazione)
 
 | Test | Comportamento verificato |
 |---|---|
@@ -111,10 +116,111 @@ Se due upstream conveyors chiamano `TryAccept` nello stesso tick, il primo vince
 | `Tick_NoNext_EntityStays` | Nessun downstream → entità rimane (jam) |
 | `StallTicks_ResetOnAccept` | `_stallTicks` azzerato ad ogni accettazione |
 
+| `SetFacing_RebuildsPortsAndReconnects` | `SetFacing` aggiorna posizioni porte e riconnette |
+
 ---
 
-## 6. Vincoli architetturali
+## 6. Layer command (Simulation)
+
+### 6.1 PlaceMergeLogicCommand
+
+```csharp
+public sealed record PlaceMergeLogicCommand(
+    GridCoord  Position,
+    Direction  Facing,
+    MergeMode  Mode  = MergeMode.Alternating,
+    float      Speed = 1f
+) : ICommand;
+```
+
+Registrata nella factory di `SimulationEngine` esattamente come gli altri `PlaceXxxCommand`.
+
+### 6.2 ConfigureComponent — branch MergeLogic
+
+Aggiunto a `SimulationEngine.ConfigureComponent`:
+
+```
+if component is MergeLogic merge:
+    "mode"   → parse "alternating"|"priority" → merge.Mode
+    "speed"  → parse float > 0 → merge.Speed
+    "facing" → parse Direction →
+                  Graph.DisconnectAll(merge)
+                  merge.SetFacing(newDir)
+                  AutoConnect(merge)
+    return Ok()
+```
+
+### 6.3 MergeLogic.SetFacing(Direction)
+
+Metodo pubblico su `MergeLogic` che ricostruisce le tre porte (`_inPort0`, `_inPort1`, `_outPort`) e aggiorna la proprietà `Facing`. Necessario perché le posizioni delle porte derivano da `Facing` e sono calcolate nel costruttore; il cambio a runtime richiede una ricostruzione esplicita.
+
+Dopo la chiamata, `SimulationEngine` invoca `AutoConnect(merge)` per ristabilire le connessioni con i nuovi vicini.
+
+---
+
+## 7. Layer controller (Webserver)
+
+### 7.1 ComponentKinds
+
+```csharp
+// SharedTypes.cs
+public const string MergeLogic = "merge";
+```
+
+Il valore `"merge"` è già usato dal frontend Angular (`sim-mock.ts`) — wire-stable.
+
+### 7.2 PlaceComponentRequest
+
+Aggiunto parametro opzionale:
+
+```csharp
+string? Mode = null   // "alternating" | "priority"
+```
+
+### 7.3 SimulationController — case merge
+
+```csharp
+ComponentKinds.MergeLogic => new PlaceMergeLogicCommand(
+    pos,
+    dir,
+    req.Mode == "priority" ? MergeMode.Priority : MergeMode.Alternating,
+    req.Speed ?? 1f),
+```
+
+### 7.4 ComponentSerializer
+
+**KindString:**
+```csharp
+SimComponentType.MergeLogic => ComponentKinds.MergeLogic,
+```
+
+**BuildProperties:**
+```csharp
+MergeLogic m => new()
+{
+    ["mode"]  = m.Mode == MergeMode.Priority ? "priority" : "alternating",
+    ["speed"] = m.Speed.ToString("F3"),
+},
+```
+
+`Facing` non va in `Properties` — è già esposto come campo top-level di `ComponentState`.
+
+### 7.5 Flusso configurazione runtime (frontend → simulazione)
+
+```
+PUT /api/sim/components/{id}
+    body: { "mode": "priority" }          → cambia logica merge
+    body: { "speed": "2.0" }              → cambia velocità
+    body: { "facing": "East" }            → ruota uscita, riconnette porte
+```
+
+Tutti e tre i casi passano per l'esistente `ConfigureComponentCommand` — nessun nuovo endpoint REST necessario.
+
+---
+
+## 9. Vincoli architetturali
 
 - `Stockflow.Simulation` deve rimanere **zero dipendenze NuGet** — nessuna dipendenza esterna introdotta
 - `MergeLogic` segue esattamente lo stesso pattern di `OneWayConveyor` e `ConveyorTurn`
 - Il campo `Occupant` esposto da `ISimComponent` rappresenta l'entità in transito (progress 0→1), non un buffer
+- `SetFacing` è chiamato **solo** dal `SimulationEngine` (dentro il tick lock, via `ConfigureComponent`), mai direttamente da codice client

--- a/Sources/Stockflow.Console/src/app/app.html
+++ b/Sources/Stockflow.Console/src/app/app.html
@@ -31,7 +31,8 @@
     (itemSelect)="onToolSelect($event)"
     (facingChange)="onFacingChange($event)"
     (turnSideChange)="onTurnSideChange($event)"
-    (speedChange)="onPlaceSpeedChange($event)">
+    (speedChange)="onPlaceSpeedChange($event)"
+    (mergeModeChange)="onPlaceMergeModeChange($event)">
   </app-palette>
 
   <app-grid-canvas

--- a/Sources/Stockflow.Console/src/app/app.ts
+++ b/Sources/Stockflow.Console/src/app/app.ts
@@ -44,6 +44,7 @@ export class App implements OnInit {
   readonly placeFacing    = signal<Direction>('North');
   readonly placeTurnSide  = signal<'Left' | 'Right'>('Right');
   readonly placeSpeed     = signal(1);
+  readonly placeMergeMode = signal<'alternating' | 'priority'>('alternating');
   readonly paused         = signal(false);
   readonly currentSpeed   = signal<SimSpeed>(1);
 
@@ -105,6 +106,10 @@ export class App implements OnInit {
     this.placeSpeed.set(speed);
   }
 
+  onPlaceMergeModeChange(mode: 'alternating' | 'priority'): void {
+    this.placeMergeMode.set(mode);
+  }
+
   @HostListener('document:keydown.escape')
   onEscape(): void {
     this.selectedTool.set(null);
@@ -117,6 +122,7 @@ export class App implements OnInit {
     const params: Record<string, unknown> = {};
     if (kind === 'conveyor_turn') params['turn'] = this.placeTurnSide();
     if (kind === 'conveyor_oneway' || kind === 'conveyor_turn') params['speed'] = this.placeSpeed();
+    if (kind === 'merge') { params['speed'] = this.placeSpeed(); params['mode'] = this.placeMergeMode(); }
     this.sim.placeComponent(kind, cell.x, cell.y, this.placeFacing(),
       Object.keys(params).length ? params as any : undefined);
   }

--- a/Sources/Stockflow.Console/src/app/core/mock/sim-mock.ts
+++ b/Sources/Stockflow.Console/src/app/core/mock/sim-mock.ts
@@ -48,7 +48,7 @@ export const COMPONENT_LIBRARY = [
   { group: 'CONVEYORS', items: [
     { id: 'conv',   name: 'Straight',    sym: '━', cost: 100,  hotkey: '1', kind: 'conveyor_oneway', live: true  },
     { id: 'curve',  name: 'Curve 90°',   sym: '┗', cost: 120,  hotkey: '2', kind: 'conveyor_turn',   live: true  },
-    { id: 'merge',  name: 'Merge',       sym: '┳', cost: 300,  hotkey: '3', kind: 'merge',           live: false },
+    { id: 'merge',  name: 'Merge',       sym: '┳', cost: 300,  hotkey: '3', kind: 'merge',           live: true  },
     { id: 'divert', name: 'Diverter',    sym: '┻', cost: 400,  hotkey: '4', kind: 'diverter',        live: false },
     { id: 'accum',  name: 'Accumulator', sym: '▣', cost: 600,  hotkey: '5', kind: 'accum',           live: false },
   ]},

--- a/Sources/Stockflow.Console/src/app/features/grid-canvas/grid-canvas.component.ts
+++ b/Sources/Stockflow.Console/src/app/features/grid-canvas/grid-canvas.component.ts
@@ -161,6 +161,27 @@ const FLOORS = [
                     text-anchor="middle" letter-spacing="0.03em" opacity="0.8">EXIT</text>
             </ng-container>
 
+            <!-- Merge Logic: primary input from left, secondary from top, output to right (East base) -->
+            <ng-container *ngSwitchCase="'merge'">
+              <rect x="1" y="1" [attr.width]="CELL-2" [attr.height]="CELL-2"
+                    fill="#0f1e28"
+                    [attr.stroke]="c.id === selectedId ? '#f5a623' : '#0e7490'"
+                    [attr.stroke-width]="c.id === selectedId ? 1.5 : 1"/>
+              <g [attr.transform]="'rotate('+facingRot(c.facing)+' '+CELL/2+' '+CELL/2+')'">
+                <line x1="3" [attr.y1]="CELL/2" [attr.x2]="CELL/2-1" [attr.y2]="CELL/2"
+                      stroke="#38bdf8" stroke-width="1.2"/>
+                <line [attr.x1]="CELL/2" y1="3" [attr.x2]="CELL/2" [attr.y2]="CELL/2-1"
+                      stroke="#38bdf8" stroke-width="1.2" opacity="0.65"/>
+                <line [attr.x1]="CELL/2+2" [attr.y1]="CELL/2" [attr.x2]="CELL-7" [attr.y2]="CELL/2"
+                      stroke="#38bdf8" stroke-width="1.2"/>
+                <polygon [attr.points]="arrowPtsMerge()" fill="#38bdf8"/>
+                <circle [attr.cx]="CELL/2" [attr.cy]="CELL/2" r="1.8" fill="#38bdf8" opacity="0.9"/>
+              </g>
+              <text [attr.x]="CELL/2" y="7"
+                    font-size="5" fill="#38bdf8" font-family="JetBrains Mono,monospace"
+                    text-anchor="middle" opacity="0.7">MRG</text>
+            </ng-container>
+
             <ng-container *ngSwitchDefault>
               <rect x="1" y="1" [attr.width]="CELL-2" [attr.height]="CELL-2"
                     fill="#181d24"
@@ -310,6 +331,7 @@ export class GridCanvasComponent implements OnChanges {
     if (!this.activeTool) return '#f5a623';
     return this.activeTool.kind === 'package_generator' ? '#4ade80'
          : this.activeTool.kind === 'package_exit'      ? '#f87171'
+         : this.activeTool.kind === 'merge'             ? '#38bdf8'
          : '#f5a623';
   }
 
@@ -317,6 +339,7 @@ export class GridCanvasComponent implements OnChanges {
     if (!this.activeTool) return 'rgba(245,166,35,.07)';
     return this.activeTool.kind === 'package_generator' ? 'rgba(74,222,128,.15)'
          : this.activeTool.kind === 'package_exit'      ? 'rgba(248,113,113,.15)'
+         : this.activeTool.kind === 'merge'             ? 'rgba(56,189,248,.15)'
          : 'rgba(245,166,35,.07)';
   }
 
@@ -410,11 +433,17 @@ export class GridCanvasComponent implements OnChanges {
     return `${x2-5},${y-3.5} ${x2},${y} ${x2-5},${y+3.5}`;
   }
 
+  arrowPtsMerge(): string {
+    const x2 = CELL - 5, y = CELL / 2;
+    return `${x2-5},${y-3} ${x2},${y} ${x2-5},${y+3}`;
+  }
+
   kindColor(kind: string): string {
     return kind === 'conveyor_oneway'   ? '#4ade80'
          : kind === 'conveyor_turn'     ? '#22d3ee'
          : kind === 'package_generator' ? '#86efac'
          : kind === 'package_exit'      ? '#fca5a5'
+         : kind === 'merge'             ? '#38bdf8'
          : '#3d4652';
   }
 

--- a/Sources/Stockflow.Console/src/app/features/inspector/inspector.component.ts
+++ b/Sources/Stockflow.Console/src/app/features/inspector/inspector.component.ts
@@ -135,8 +135,33 @@ const KIND_LABELS: Record<string, string> = {
           </div>
         </ng-container>
 
+        <!-- ── MERGE LOGIC ──────────────────────────────── -->
+        <ng-container *ngIf="isMerge">
+          <div class="panel-head"><span>CONFIG</span></div>
+          <div class="sec form-sec">
+            <div class="field">
+              <label class="field-lbl">MODE</label>
+              <div class="facing-btns">
+                <button class="dbtn" [class.on]="editMergeMode === 'alternating'" (click)="editMergeMode = 'alternating'">ALTERNATING</button>
+                <button class="dbtn" [class.on]="editMergeMode === 'priority'"    (click)="editMergeMode = 'priority'">PRIORITY</button>
+              </div>
+            </div>
+            <div class="field">
+              <label class="field-lbl">Speed <span class="unit">cell/s</span></label>
+              <input class="field-input" type="number" [(ngModel)]="editMergeSpeed"
+                     min="0.1" max="10" step="0.1"/>
+            </div>
+            <button class="save-btn" (click)="saveMerge()">APPLY CHANGES</button>
+          </div>
+          <div class="panel-head"><span>PROPERTIES</span></div>
+          <div class="sec">
+            <div class="row"><div class="k">Grid</div><div class="v">({{ selected.gridX }}, {{ selected.gridY }})</div></div>
+            <div class="row"><div class="k">Facing</div><div class="v">{{ selected.facing }}</div></div>
+          </div>
+        </ng-container>
+
         <!-- ── OTHER COMPONENTS ──────────────────────────── -->
-        <ng-container *ngIf="!isGenerator && !isExit && !isConveyor">
+        <ng-container *ngIf="!isGenerator && !isExit && !isConveyor && !isMerge">
           <div class="panel-head"><span>PROPERTIES</span></div>
           <div class="sec">
             <div class="row"><div class="k">Kind</div><div class="v">{{ selected.kind }}</div></div>
@@ -253,6 +278,23 @@ const KIND_LABELS: Record<string, string> = {
     }
     .del-btn:hover { background: rgba(248,113,113,.16); }
 
+    /* Merge mode buttons */
+    .facing-btns { display: flex; gap: 3px; }
+    .dbtn {
+      flex: 1;
+      padding: 4px 0;
+      border: 1px solid var(--border-bright);
+      background: transparent;
+      color: var(--text-3);
+      font-family: var(--mono);
+      font-size: 9px;
+      cursor: pointer;
+      letter-spacing: .04em;
+      transition: all .1s;
+    }
+    .dbtn.on { color: var(--cyan); border-color: var(--cyan-dim); background: rgba(34,211,238,.06); font-weight: 700; }
+    .dbtn:hover:not(.on) { background: var(--bg-2); color: var(--text-1); }
+
     /* Exit metrics */
     .metrics-sec { display: flex; flex-direction: column; gap: 6px; }
     .metric-card {
@@ -281,10 +323,12 @@ export class InspectorComponent implements OnChanges {
 
   private sim = inject(SimStateService);
 
-  editSpawnRate = 1;
-  editSku = 'PKG';
-  editEnabled = true;
-  editSpeed = 1;
+  editSpawnRate  = 1;
+  editSku        = 'PKG';
+  editEnabled    = true;
+  editSpeed      = 1;
+  editMergeMode: 'alternating' | 'priority' = 'alternating';
+  editMergeSpeed = 1;
 
   get kindLabel(): string {
     return this.selected ? (KIND_LABELS[this.selected.kind] ?? this.selected.kind.toUpperCase()) : '';
@@ -292,6 +336,7 @@ export class InspectorComponent implements OnChanges {
 
   get isGenerator(): boolean { return this.selected?.kind === 'package_generator'; }
   get isExit():      boolean { return this.selected?.kind === 'package_exit'; }
+  get isMerge():     boolean { return this.selected?.kind === 'merge'; }
   get isConveyor():  boolean {
     return this.selected?.kind === 'conveyor_oneway' || this.selected?.kind === 'conveyor_turn';
   }
@@ -305,6 +350,10 @@ export class InspectorComponent implements OnChanges {
     }
     if (this.isConveyor) {
       this.editSpeed = parseFloat(p['speed'] ?? '1');
+    }
+    if (this.isMerge) {
+      this.editMergeMode  = (p['mode'] ?? 'alternating') as 'alternating' | 'priority';
+      this.editMergeSpeed = parseFloat(p['speed'] ?? '1');
     }
   }
 
@@ -324,6 +373,14 @@ export class InspectorComponent implements OnChanges {
   saveConveyor(): void {
     if (!this.selected) return;
     this.sim.configureComponent(this.selected.id, { speed: String(this.editSpeed) });
+  }
+
+  saveMerge(): void {
+    if (!this.selected) return;
+    this.sim.configureComponent(this.selected.id, {
+      mode:  this.editMergeMode,
+      speed: String(this.editMergeSpeed),
+    });
   }
 
   deleteComponent(): void {

--- a/Sources/Stockflow.Console/src/app/features/palette/palette.component.ts
+++ b/Sources/Stockflow.Console/src/app/features/palette/palette.component.ts
@@ -64,7 +64,16 @@ export interface PaletteItem {
         </div>
       </div>
 
-      <!-- Speed input (shown for conveyors) -->
+      <!-- Mode selector (shown only for merge) -->
+      <div class="facing" *ngIf="isMerge">
+        <div class="facing-lbl">MODE</div>
+        <div class="facing-btns">
+          <button class="dbtn" [class.on]="selectedMergeMode === 'alternating'" (click)="setMergeMode('alternating')">ALT</button>
+          <button class="dbtn" [class.on]="selectedMergeMode === 'priority'"    (click)="setMergeMode('priority')">PRI</button>
+        </div>
+      </div>
+
+      <!-- Speed input (shown for conveyors and merge) -->
       <div class="facing" *ngIf="isConveyor">
         <div class="facing-lbl">SPEED <span class="dim2">cell/s</span></div>
         <input class="speed-input" type="number"
@@ -183,16 +192,18 @@ export interface PaletteItem {
 })
 export class PaletteComponent {
   @Input()  selectedId: string | null = null;
-  @Output() itemSelect    = new EventEmitter<PaletteItem | null>();
-  @Output() facingChange  = new EventEmitter<Direction>();
-  @Output() turnSideChange = new EventEmitter<'Left' | 'Right'>();
-  @Output() speedChange   = new EventEmitter<number>();
+  @Output() itemSelect      = new EventEmitter<PaletteItem | null>();
+  @Output() facingChange    = new EventEmitter<Direction>();
+  @Output() turnSideChange  = new EventEmitter<'Left' | 'Right'>();
+  @Output() speedChange     = new EventEmitter<number>();
+  @Output() mergeModeChange = new EventEmitter<'alternating' | 'priority'>();
 
   readonly lib = COMPONENT_LIBRARY;
   readonly directions: Direction[] = ['North', 'East', 'South', 'West'];
   selectedFacing: Direction = 'North';
   selectedTurnSide: 'Left' | 'Right' = 'Right';
   selectedSpeed = 1;
+  selectedMergeMode: 'alternating' | 'priority' = 'alternating';
 
   get selectedItem(): PaletteItem | null {
     if (!this.selectedId) return null;
@@ -203,13 +214,12 @@ export class PaletteComponent {
     return null;
   }
 
-  get isConveyorTurn(): boolean {
-    return this.selectedItem?.kind === 'conveyor_turn';
-  }
+  get isConveyorTurn(): boolean { return this.selectedItem?.kind === 'conveyor_turn'; }
+  get isMerge():        boolean { return this.selectedItem?.kind === 'merge'; }
 
   get isConveyor(): boolean {
     const kind = this.selectedItem?.kind;
-    return kind === 'conveyor_oneway' || kind === 'conveyor_turn';
+    return kind === 'conveyor_oneway' || kind === 'conveyor_turn' || kind === 'merge';
   }
 
   select(it: PaletteItem): void {
@@ -230,5 +240,10 @@ export class PaletteComponent {
   setSpeed(value: number): void {
     this.selectedSpeed = Math.max(0.1, Math.min(10, value));
     this.speedChange.emit(this.selectedSpeed);
+  }
+
+  setMergeMode(mode: 'alternating' | 'priority'): void {
+    this.selectedMergeMode = mode;
+    this.mergeModeChange.emit(mode);
   }
 }

--- a/Sources/Stockflow.Protocol/Messages/SharedTypes.cs
+++ b/Sources/Stockflow.Protocol/Messages/SharedTypes.cs
@@ -32,6 +32,7 @@ public static class ComponentKinds
     public const string ConveyorTurn     = "conveyor_turn";
     public const string PackageGenerator = "package_generator";
     public const string PackageExit      = "package_exit";
+    public const string MergeLogic       = "merge";
 }
 
 /// <summary>

--- a/Sources/Stockflow.Simulation/Commands/PlaceComponentCommand.cs
+++ b/Sources/Stockflow.Simulation/Commands/PlaceComponentCommand.cs
@@ -30,4 +30,11 @@ public sealed record PlaceConveyorTurnCommand(
     float     Speed = 1f
 ) : ICommand;
 
+public sealed record PlaceMergeLogicCommand(
+    GridCoord Position,
+    Direction Facing,
+    MergeMode Mode  = MergeMode.Alternating,
+    float     Speed = 1f
+) : ICommand;
+
 public sealed record RemoveComponentCommand(int ComponentId) : ICommand;

--- a/Sources/Stockflow.Simulation/Component/ComponentType.cs
+++ b/Sources/Stockflow.Simulation/Component/ComponentType.cs
@@ -6,4 +6,5 @@ public enum ComponentType
     ConveyorTurn,
     PackageGenerator,
     PackageExit,
+    MergeLogic,
 }

--- a/Sources/Stockflow.Simulation/Component/MergeLogic.cs
+++ b/Sources/Stockflow.Simulation/Component/MergeLogic.cs
@@ -21,10 +21,14 @@ public class MergeLogic : ISimComponent
     private Port   _inPort0;
     private Port   _inPort1;
     private Port   _outPort;
-    private Port[] _ports = null!;
+    private Port[] _ports = [];
     private PortId _activePort;
     private int    _stallTicks;
     private const int StallThreshold = 30;
+
+    private static readonly PortId _port0 = new(0);
+    private static readonly PortId _port1 = new(1);
+    private static readonly PortId _port2 = new(2);
 
     public MergeLogic(int id, GridCoord position, Direction facing, MergeMode mode, float speed,
                       RoutingGraph graph, IReadOnlyList<IComponentModule>? modules = null)
@@ -35,45 +39,44 @@ public class MergeLogic : ISimComponent
         Speed       = speed;
         Graph       = graph;
         Modules     = modules ?? [];
-        _activePort = new PortId(0);
+        _activePort = _port0;
         SetFacing(facing);
     }
 
     public void SetFacing(Direction facing)
     {
         Facing   = facing;
-        _inPort0 = new(new PortId(0), Position + facing.Opposite().ToOffset(),  PortDirection.In);
-        _inPort1 = new(new PortId(1), Position + facing.RotateCCW().ToOffset(), PortDirection.In);
-        _outPort = new(new PortId(2), Position + facing.ToOffset(),             PortDirection.Out);
+        _inPort0 = new(_port0, Position + facing.Opposite().ToOffset(),  PortDirection.In);
+        _inPort1 = new(_port1, Position + facing.RotateCCW().ToOffset(), PortDirection.In);
+        _outPort = new(_port2, Position + facing.ToOffset(),             PortDirection.Out);
         _ports   = [_inPort0, _inPort1, _outPort];
     }
 
     public void Tick(float deltaTime)
     {
-        if (Occupant != null)
-        {
-            if (Occupant.Progress < 1.0f)
-            {
-                Occupant.Progress += Speed * deltaTime;
-            }
-            else
-            {
-                var next = Graph.GetNext(this, _outPort.Id);
-                if (next != null && next.Value.To.TryAccept(Occupant, next.Value.ToPort))
-                {
-                    foreach (var module in Modules)
-                        module.OnEntityExit(Occupant);
-                    Occupant = null;
-                }
-            }
-        }
-        else
+        if (Occupant == null)
         {
             _stallTicks++;
             if (_stallTicks >= StallThreshold)
             {
-                _activePort = _activePort == new PortId(0) ? new PortId(1) : new PortId(0);
+                _activePort = _activePort == _port0 ? _port1 : _port0;
                 _stallTicks = 0;
+            }
+            return;
+        }
+
+        if (Occupant.Progress < 1.0f)
+        {
+            Occupant.Progress += Speed * deltaTime;
+        }
+        else
+        {
+            var next = Graph.GetNext(this, _outPort.Id);
+            if (next != null && next.Value.To.TryAccept(Occupant, next.Value.ToPort))
+            {
+                foreach (var module in Modules)
+                    module.OnEntityExit(Occupant);
+                Occupant = null;
             }
         }
     }
@@ -90,9 +93,9 @@ public class MergeLogic : ISimComponent
         _stallTicks             = 0;
 
         if (Mode == MergeMode.Alternating)
-            _activePort = _activePort == new PortId(0) ? new PortId(1) : new PortId(0);
+            _activePort = _activePort == _port0 ? _port1 : _port0;
         else
-            _activePort = new PortId(0);
+            _activePort = _port0;
 
         foreach (var module in Modules)
             module.OnEntityEnter(entity);

--- a/Sources/Stockflow.Simulation/Component/MergeLogic.cs
+++ b/Sources/Stockflow.Simulation/Component/MergeLogic.cs
@@ -1,0 +1,102 @@
+using Stockflow.Simulation.Entity;
+using Stockflow.Simulation.Grid;
+using Stockflow.Simulation.Modules;
+using Stockflow.Simulation.Routing;
+
+namespace Stockflow.Simulation.Component;
+
+public class MergeLogic : ISimComponent
+{
+    public  int                             Id       { get; }
+    public  GridCoord                       Position { get; }
+    public  Direction                       Facing   { get; private set; }
+    public  ComponentType                   Type     => ComponentType.MergeLogic;
+    public  IReadOnlyList<IComponentModule> Modules  { get; }
+    public  SimEntity?                      Occupant { get; private set; }
+    public  IReadOnlyList<Port>             Ports    => _ports;
+    public  float                           Speed    { get; set; }
+    public  MergeMode                       Mode     { get; set; }
+    public  RoutingGraph                    Graph    { get; }
+
+    private Port   _inPort0;
+    private Port   _inPort1;
+    private Port   _outPort;
+    private Port[] _ports = null!;
+    private PortId _activePort;
+    private int    _stallTicks;
+    private const int StallThreshold = 30;
+
+    public MergeLogic(int id, GridCoord position, Direction facing, MergeMode mode, float speed,
+                      RoutingGraph graph, IReadOnlyList<IComponentModule>? modules = null)
+    {
+        Id          = id;
+        Position    = position;
+        Mode        = mode;
+        Speed       = speed;
+        Graph       = graph;
+        Modules     = modules ?? [];
+        _activePort = new PortId(0);
+        SetFacing(facing);
+    }
+
+    public void SetFacing(Direction facing)
+    {
+        Facing   = facing;
+        _inPort0 = new(new PortId(0), Position + facing.Opposite().ToOffset(),  PortDirection.In);
+        _inPort1 = new(new PortId(1), Position + facing.RotateCCW().ToOffset(), PortDirection.In);
+        _outPort = new(new PortId(2), Position + facing.ToOffset(),             PortDirection.Out);
+        _ports   = [_inPort0, _inPort1, _outPort];
+    }
+
+    public void Tick(float deltaTime)
+    {
+        if (Occupant != null)
+        {
+            if (Occupant.Progress < 1.0f)
+            {
+                Occupant.Progress += Speed * deltaTime;
+            }
+            else
+            {
+                var next = Graph.GetNext(this, _outPort.Id);
+                if (next != null && next.Value.To.TryAccept(Occupant, next.Value.ToPort))
+                {
+                    foreach (var module in Modules)
+                        module.OnEntityExit(Occupant);
+                    Occupant = null;
+                }
+            }
+        }
+        else
+        {
+            _stallTicks++;
+            if (_stallTicks >= StallThreshold)
+            {
+                _activePort = _activePort == new PortId(0) ? new PortId(1) : new PortId(0);
+                _stallTicks = 0;
+            }
+        }
+    }
+
+    public bool TryAccept(SimEntity entity, PortId fromPort)
+    {
+        if (Occupant != null) return false;
+        if (fromPort != _activePort) return false;
+
+        Occupant                = entity;
+        entity.CurrentComponent = this;
+        entity.CurrentPort      = fromPort;
+        entity.Progress         = 0.0f;
+        _stallTicks             = 0;
+
+        if (Mode == MergeMode.Alternating)
+            _activePort = _activePort == new PortId(0) ? new PortId(1) : new PortId(0);
+        else
+            _activePort = new PortId(0);
+
+        foreach (var module in Modules)
+            module.OnEntityEnter(entity);
+
+        return true;
+    }
+}

--- a/Sources/Stockflow.Simulation/Component/MergeMode.cs
+++ b/Sources/Stockflow.Simulation/Component/MergeMode.cs
@@ -1,0 +1,3 @@
+namespace Stockflow.Simulation.Component;
+
+public enum MergeMode { Alternating, Priority }

--- a/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
+++ b/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
@@ -45,6 +45,11 @@ public class SimulationEngine
                 var x = (PlacePackageExitCommand)c;
                 return new PackageExit(id, x.Position, x.Facing, State.Entities);
             },
+            [typeof(PlaceMergeLogicCommand)] = (c, id) =>
+            {
+                var x = (PlaceMergeLogicCommand)c;
+                return new MergeLogic(id, x.Position, x.Facing, x.Mode, x.Speed, Graph);
+            },
         };
     }
 
@@ -144,6 +149,21 @@ public class SimulationEngine
         {
             if (cmd.Properties.TryGetValue("speed", out var sp) && float.TryParse(sp, out var speed) && speed > 0)
                 turn.Speed = speed;
+            return CommandResult.Ok();
+        }
+        if (component is MergeLogic merge)
+        {
+            if (cmd.Properties.TryGetValue("mode", out var modeStr))
+                merge.Mode = modeStr == "priority" ? MergeMode.Priority : MergeMode.Alternating;
+            if (cmd.Properties.TryGetValue("speed", out var sp) && float.TryParse(sp, out var speed) && speed > 0)
+                merge.Speed = speed;
+            if (cmd.Properties.TryGetValue("facing", out var facingStr) &&
+                Enum.TryParse<Direction>(facingStr, out var newDir))
+            {
+                Graph.DisconnectAll(merge);
+                merge.SetFacing(newDir);
+                AutoConnect(merge);
+            }
             return CommandResult.Ok();
         }
         return component is null

--- a/Sources/Stockflow.Tests.Simulation/MergeLogicTests.cs
+++ b/Sources/Stockflow.Tests.Simulation/MergeLogicTests.cs
@@ -201,4 +201,22 @@ public class MergeLogicTests
         var e2 = mgr.Spawn("B", 1f, 1f, 0f, merge, new PortId(1));
         Assert.False(merge.TryAccept(e2, new PortId(1)));
     }
+
+    [Fact]
+    public void SetFacing_RebuildsPortPositions()
+    {
+        var merge = MakeMerge(); // default Facing=North, Position=(0,0)
+
+        // Facing=North: port0=South=(0,1), port1=West=(-1,0), port2=North=(0,-1)
+        Assert.Equal(new GridCoord(0,   1), merge.Ports[0].Position);
+        Assert.Equal(new GridCoord(-1,  0), merge.Ports[1].Position);
+        Assert.Equal(new GridCoord(0,  -1), merge.Ports[2].Position);
+
+        merge.SetFacing(Direction.East);
+
+        // Facing=East: port0=West=(-1,0), port1=North=(0,-1), port2=East=(1,0)
+        Assert.Equal(new GridCoord(-1,  0), merge.Ports[0].Position);
+        Assert.Equal(new GridCoord(0,  -1), merge.Ports[1].Position);
+        Assert.Equal(new GridCoord(1,   0), merge.Ports[2].Position);
+    }
 }

--- a/Sources/Stockflow.Tests.Simulation/MergeLogicTests.cs
+++ b/Sources/Stockflow.Tests.Simulation/MergeLogicTests.cs
@@ -1,0 +1,204 @@
+using Stockflow.Simulation.Component;
+using Stockflow.Simulation.Entity;
+using Stockflow.Simulation.Grid;
+using Stockflow.Simulation.Routing;
+
+namespace Stockflow.Tests.Simulation;
+
+public class MergeLogicTests
+{
+    private static MergeLogic MakeMerge(
+        MergeMode    mode  = MergeMode.Alternating,
+        RoutingGraph? graph = null)
+        => new(1, new GridCoord(0, 0), Direction.North, mode, 1f,
+               graph ?? new RoutingGraph());
+
+    [Fact]
+    public void TryAccept_EmptySlot_In0_Accepts()
+    {
+        var merge  = MakeMerge();
+        var entity = new EntityManager().Spawn("A", 1f, 1f, 0f, merge, new PortId(0));
+
+        Assert.True(merge.TryAccept(entity, new PortId(0)));
+        Assert.Same(merge, entity.CurrentComponent);
+        Assert.Equal(0f, entity.Progress);
+    }
+
+    [Fact]
+    public void TryAccept_EmptySlot_In1_Rejected_Initially()
+    {
+        var merge  = MakeMerge();
+        var entity = new EntityManager().Spawn("A", 1f, 1f, 0f, merge, new PortId(1));
+
+        Assert.False(merge.TryAccept(entity, new PortId(1)));
+        Assert.Null(merge.Occupant);
+    }
+
+    [Fact]
+    public void TryAccept_OccupiedSlot_ReturnsFalse()
+    {
+        var merge = MakeMerge();
+        var mgr   = new EntityManager();
+        var e1    = mgr.Spawn("A", 1f, 1f, 0f, merge, new PortId(0));
+        var e2    = mgr.Spawn("B", 1f, 1f, 0f, merge, new PortId(0));
+        merge.TryAccept(e1, new PortId(0));
+
+        Assert.False(merge.TryAccept(e2, new PortId(0)));
+    }
+
+    [Fact]
+    public void Alternating_AfterIn0_ActiveSwitchesToIn1()
+    {
+        var graph = new RoutingGraph();
+        var merge = MakeMerge(MergeMode.Alternating, graph);
+        var mgr   = new EntityManager();
+        var exit  = new PackageExit(2, new GridCoord(0, -1), Direction.North, mgr);
+        graph.Connect(merge, new PortId(2), exit, new PortId(0));
+
+        var e1 = mgr.Spawn("A", 1f, 1f, 0f, merge, new PortId(0));
+        merge.TryAccept(e1, new PortId(0));
+        merge.Tick(1f); merge.Tick(0f); exit.Tick(0f);
+
+        var e2 = mgr.Spawn("B", 1f, 1f, 0f, merge, new PortId(0));
+        Assert.False(merge.TryAccept(e2, new PortId(0)));
+        var e3 = mgr.Spawn("C", 1f, 1f, 0f, merge, new PortId(1));
+        Assert.True(merge.TryAccept(e3, new PortId(1)));
+    }
+
+    [Fact]
+    public void Alternating_AfterIn1_ActiveSwitchesToIn0()
+    {
+        var graph = new RoutingGraph();
+        var merge = MakeMerge(MergeMode.Alternating, graph);
+        var mgr   = new EntityManager();
+        var exit  = new PackageExit(2, new GridCoord(0, -1), Direction.North, mgr);
+        graph.Connect(merge, new PortId(2), exit, new PortId(0));
+
+        var e1 = mgr.Spawn("A", 1f, 1f, 0f, merge, new PortId(0));
+        merge.TryAccept(e1, new PortId(0));
+        merge.Tick(1f); merge.Tick(0f); exit.Tick(0f);
+
+        var e2 = mgr.Spawn("B", 1f, 1f, 0f, merge, new PortId(1));
+        merge.TryAccept(e2, new PortId(1));
+        merge.Tick(1f); merge.Tick(0f); exit.Tick(0f);
+
+        var e3 = mgr.Spawn("C", 1f, 1f, 0f, merge, new PortId(1));
+        Assert.False(merge.TryAccept(e3, new PortId(1)));
+        var e4 = mgr.Spawn("D", 1f, 1f, 0f, merge, new PortId(0));
+        Assert.True(merge.TryAccept(e4, new PortId(0)));
+    }
+
+    [Fact]
+    public void Priority_AfterIn0_ActiveStaysIn0()
+    {
+        var graph = new RoutingGraph();
+        var merge = MakeMerge(MergeMode.Priority, graph);
+        var mgr   = new EntityManager();
+        var exit  = new PackageExit(2, new GridCoord(0, -1), Direction.North, mgr);
+        graph.Connect(merge, new PortId(2), exit, new PortId(0));
+
+        var e1 = mgr.Spawn("A", 1f, 1f, 0f, merge, new PortId(0));
+        merge.TryAccept(e1, new PortId(0));
+        merge.Tick(1f); merge.Tick(0f); exit.Tick(0f);
+
+        var e2 = mgr.Spawn("B", 1f, 1f, 0f, merge, new PortId(1));
+        Assert.False(merge.TryAccept(e2, new PortId(1)));
+        var e3 = mgr.Spawn("C", 1f, 1f, 0f, merge, new PortId(0));
+        Assert.True(merge.TryAccept(e3, new PortId(0)));
+    }
+
+    [Fact]
+    public void Priority_StallThreshold_SwitchesToIn1()
+    {
+        var merge = MakeMerge(MergeMode.Priority);
+        var mgr   = new EntityManager();
+
+        for (int i = 0; i < 30; i++) merge.Tick(0f);
+
+        var entity = mgr.Spawn("A", 1f, 1f, 0f, merge, new PortId(1));
+        Assert.True(merge.TryAccept(entity, new PortId(1)));
+    }
+
+    [Fact]
+    public void Priority_AfterIn1Accepts_BackToIn0()
+    {
+        var graph = new RoutingGraph();
+        var merge = MakeMerge(MergeMode.Priority, graph);
+        var mgr   = new EntityManager();
+        var exit  = new PackageExit(2, new GridCoord(0, -1), Direction.North, mgr);
+        graph.Connect(merge, new PortId(2), exit, new PortId(0));
+
+        for (int i = 0; i < 30; i++) merge.Tick(0f);
+
+        var e1 = mgr.Spawn("A", 1f, 1f, 0f, merge, new PortId(1));
+        merge.TryAccept(e1, new PortId(1));
+        merge.Tick(1f); merge.Tick(0f); exit.Tick(0f);
+
+        var e2 = mgr.Spawn("B", 1f, 1f, 0f, merge, new PortId(1));
+        Assert.False(merge.TryAccept(e2, new PortId(1)));
+        var e3 = mgr.Spawn("C", 1f, 1f, 0f, merge, new PortId(0));
+        Assert.True(merge.TryAccept(e3, new PortId(0)));
+    }
+
+    [Fact]
+    public void Tick_ProgressAdvances()
+    {
+        var merge  = MakeMerge();
+        var entity = new EntityManager().Spawn("A", 1f, 1f, 0f, merge, new PortId(0));
+        merge.TryAccept(entity, new PortId(0));
+
+        merge.Tick(0.5f);
+
+        Assert.Equal(0.5f, entity.Progress);
+    }
+
+    [Fact]
+    public void Tick_EntityComplete_TransfersDownstream()
+    {
+        var graph      = new RoutingGraph();
+        var merge      = MakeMerge(graph: graph);
+        var downstream = new OneWayConveyor(2, new GridCoord(0, -1), Direction.North, 1f, graph);
+        graph.Connect(merge, new PortId(2), downstream, new PortId(0));
+
+        var entity = new EntityManager().Spawn("A", 1f, 1f, 0f, merge, new PortId(0));
+        merge.TryAccept(entity, new PortId(0));
+        merge.Tick(1f);
+        merge.Tick(0f);
+
+        Assert.Null(merge.Occupant);
+        Assert.Same(downstream, entity.CurrentComponent);
+    }
+
+    [Fact]
+    public void Tick_NoNext_EntityStays()
+    {
+        var merge  = MakeMerge();
+        var entity = new EntityManager().Spawn("A", 1f, 1f, 0f, merge, new PortId(0));
+        merge.TryAccept(entity, new PortId(0));
+        merge.Tick(1f);
+        merge.Tick(0f);
+
+        Assert.Same(entity, merge.Occupant);
+    }
+
+    [Fact]
+    public void StallTicks_ResetOnAccept()
+    {
+        var graph = new RoutingGraph();
+        var merge = MakeMerge(MergeMode.Priority, graph);
+        var mgr   = new EntityManager();
+        var exit  = new PackageExit(2, new GridCoord(0, -1), Direction.North, mgr);
+        graph.Connect(merge, new PortId(2), exit, new PortId(0));
+
+        for (int i = 0; i < 15; i++) merge.Tick(0f);
+
+        var e1 = mgr.Spawn("A", 1f, 1f, 0f, merge, new PortId(0));
+        merge.TryAccept(e1, new PortId(0));
+        merge.Tick(1f); merge.Tick(0f); exit.Tick(0f);
+
+        for (int i = 0; i < 29; i++) merge.Tick(0f);
+
+        var e2 = mgr.Spawn("B", 1f, 1f, 0f, merge, new PortId(1));
+        Assert.False(merge.TryAccept(e2, new PortId(1)));
+    }
+}

--- a/Sources/Stockflow.Tests.Simulation/SimulationEngineTests.cs
+++ b/Sources/Stockflow.Tests.Simulation/SimulationEngineTests.cs
@@ -1,3 +1,4 @@
+using Stockflow.Simulation.Commands;
 using Stockflow.Simulation.Component;
 using Stockflow.Simulation.Core;
 using Stockflow.Simulation.Entity;
@@ -99,5 +100,52 @@ public class SimulationEngineTests
         engine.Tick(0.1f);
 
         Assert.Equal(0.1f, engine.SimulationTime, precision: 5);
+    }
+
+    [Fact]
+    public void PlaceMergeLogic_AddsComponentToState()
+    {
+        var engine = new SimulationEngine(10, 10, 1);
+        var cmd    = new PlaceMergeLogicCommand(new GridCoord(5, 5), Direction.North);
+
+        engine.ProcessCommand(cmd);
+
+        var comp = engine.State.Components.Find(c => c.Type == ComponentType.MergeLogic);
+        Assert.NotNull(comp);
+        Assert.Equal(new GridCoord(5, 5), comp.Position);
+    }
+
+    [Fact]
+    public void ConfigureMergeLogic_UpdatesModeAndSpeed()
+    {
+        var engine = new SimulationEngine(10, 10, 1);
+        engine.ProcessCommand(new PlaceMergeLogicCommand(new GridCoord(5, 5), Direction.North));
+        var merge = (MergeLogic)engine.State.Components.Find(c => c.Type == ComponentType.MergeLogic)!;
+
+        engine.ProcessCommand(new ConfigureComponentCommand(merge.Id, new Dictionary<string, string>
+        {
+            ["mode"]  = "priority",
+            ["speed"] = "2.5",
+        }));
+
+        Assert.Equal(MergeMode.Priority, merge.Mode);
+        Assert.Equal(2.5f, merge.Speed);
+    }
+
+    [Fact]
+    public void ConfigureMergeLogic_SetFacing_RebuildsPortPositions()
+    {
+        var engine = new SimulationEngine(10, 10, 1);
+        engine.ProcessCommand(new PlaceMergeLogicCommand(new GridCoord(5, 5), Direction.North));
+        var merge = (MergeLogic)engine.State.Components.Find(c => c.Type == ComponentType.MergeLogic)!;
+
+        engine.ProcessCommand(new ConfigureComponentCommand(merge.Id, new Dictionary<string, string>
+        {
+            ["facing"] = "East",
+        }));
+
+        Assert.Equal(Direction.East, merge.Facing);
+        // Facing=East: outPort at (6,5)
+        Assert.Equal(new GridCoord(6, 5), merge.Ports[2].Position);
     }
 }

--- a/Sources/Stockflow.Webserver/Controllers/SimulationController.cs
+++ b/Sources/Stockflow.Webserver/Controllers/SimulationController.cs
@@ -127,6 +127,11 @@ public sealed class SimulationController(
             ComponentKinds.ConveyorTurn   => new PlaceConveyorTurnCommand(pos, dir,
                 req.Turn == "Left" ? TurnSide.Left : TurnSide.Right,
                 req.Speed ?? 1f),
+            ComponentKinds.MergeLogic => new PlaceMergeLogicCommand(
+                pos,
+                dir,
+                req.Mode == "priority" ? MergeMode.Priority : MergeMode.Alternating,
+                req.Speed ?? 1f),
             _ => null,
         };
 
@@ -190,4 +195,5 @@ public sealed record PlaceComponentRequest(
     float?  Weight    = null,
     float?  Size      = null,
     string? Turn      = null,
-    float?  Speed     = null);
+    float?  Speed     = null,
+    string? Mode      = null);

--- a/Sources/Stockflow.Webserver/Serialization/ComponentSerializer.cs
+++ b/Sources/Stockflow.Webserver/Serialization/ComponentSerializer.cs
@@ -17,6 +17,7 @@ public static class ComponentSerializer
         SimComponentType.ConveyorTurn     => ComponentKinds.ConveyorTurn,
         SimComponentType.PackageGenerator => ComponentKinds.PackageGenerator,
         SimComponentType.PackageExit      => ComponentKinds.PackageExit,
+        SimComponentType.MergeLogic       => ComponentKinds.MergeLogic,
         _                                 => type.ToString().ToLowerInvariant(),
     };
 
@@ -44,6 +45,11 @@ public static class ComponentSerializer
         OneWayConveyor conv => new()
         {
             ["speed"] = conv.Speed.ToString("F3"),
+        },
+        MergeLogic m => new()
+        {
+            ["mode"]  = m.Mode == MergeMode.Priority ? "priority" : "alternating",
+            ["speed"] = m.Speed.ToString("F3"),
         },
         _ => null,
     };


### PR DESCRIPTION
## Summary

- Aggiunge `MergeLogic`: componente 1×1 con 2 ingressi e 1 uscita, logica configurabile `Alternating` (round-robin) e `Priority` (porta 0 preferita con anti-starvation a 30 tick)
- Integra il componente nell'engine (`PlaceMergeLogicCommand`, factory, `ConfigureComponent` con supporto a `mode`/`speed`/`facing` a runtime)
- Espone il componente nel layer webserver (REST `POST /api/sim/components` + `PUT` per riconfigurazione, serializzazione, `sim-mock.ts live: true`)

## Test Plan

- [x] 13 unit test `MergeLogicTests` (TryAccept, Tick, logica Alternating/Priority, stall threshold, SetFacing) — tutti verdi
- [x] 3 integration test `SimulationEngineTests` (placement, configure mode+speed, configure facing) — tutti verdi
- [x] Build solution senza warning: `dotnet build Stockflow.slnx`
- [x] Suite completa: `dotnet test` → 97/97 passati
- [ ] Verifica manuale via REST: `POST /api/sim/components` con `kind: "merge"`, poi `PUT /api/sim/components/{id}` con `{"mode":"priority"}`

Closes #23

🤖 Generated with [Claude Code](https://claude.ai/claude-code)