### PR TITLE
feat: DiverterLogic con routing rules configurabili (closes #24)

### DIFF
--- a/Sources/Stockflow.Console/src/app/core/mock/sim-mock.ts
+++ b/Sources/Stockflow.Console/src/app/core/mock/sim-mock.ts
@@ -49,7 +49,7 @@ export const COMPONENT_LIBRARY = [
     { id: 'conv',   name: 'Straight',    sym: '━', cost: 100,  hotkey: '1', kind: 'conveyor_oneway', live: true  },
     { id: 'curve',  name: 'Curve 90°',   sym: '┗', cost: 120,  hotkey: '2', kind: 'conveyor_turn',   live: true  },
     { id: 'merge',  name: 'Merge',       sym: '┳', cost: 300,  hotkey: '3', kind: 'merge',           live: true  },
-    { id: 'divert', name: 'Diverter',    sym: '┻', cost: 400,  hotkey: '4', kind: 'diverter',        live: false },
+    { id: 'divert', name: 'Diverter',    sym: '┻', cost: 400,  hotkey: '4', kind: 'diverter',        live: true  },
     { id: 'accum',  name: 'Accumulator', sym: '▣', cost: 600,  hotkey: '5', kind: 'accum',           live: false },
   ]},
   { group: 'STORAGE', items: [

--- a/Sources/Stockflow.Console/src/app/features/grid-canvas/grid-canvas.component.ts
+++ b/Sources/Stockflow.Console/src/app/features/grid-canvas/grid-canvas.component.ts
@@ -187,6 +187,27 @@ const FLOORS = [
                       text-anchor="middle" opacity="0.7">MRG</text>
               </ng-container>
 
+              <ng-container *ngSwitchCase="'diverter'">
+                <rect x="1" y="1" [attr.width]="CELL-2" [attr.height]="CELL-2"
+                      fill="#120d1e"
+                      [attr.stroke]="c.id === selectedId ? '#f5a623' : '#6d28d9'"
+                      [attr.stroke-width]="c.id === selectedId ? 1.5 : 1"/>
+                <g [attr.transform]="'rotate('+facingRot(c.facing)+' '+CELL/2+' '+CELL/2+')'">
+                  <line x1="3" [attr.y1]="CELL/2" [attr.x2]="CELL/2-1" [attr.y2]="CELL/2"
+                        stroke="#a78bfa" stroke-width="1.2"/>
+                  <line [attr.x1]="CELL/2+2" [attr.y1]="CELL/2" [attr.x2]="CELL-7" [attr.y2]="CELL/2"
+                        stroke="#a78bfa" stroke-width="1.2"/>
+                  <line [attr.x1]="CELL/2" [attr.y1]="CELL/2+2" [attr.x2]="CELL/2" [attr.y2]="CELL-7"
+                        stroke="#a78bfa" stroke-width="1.2" opacity="0.65"/>
+                  <polygon [attr.points]="arrowPtsMerge()" fill="#a78bfa"/>
+                  <polygon [attr.points]="arrowPtsDivertSide()" fill="#a78bfa"/>
+                  <circle [attr.cx]="CELL/2" [attr.cy]="CELL/2" r="1.8" fill="#a78bfa" opacity="0.9"/>
+                </g>
+                <text [attr.x]="CELL/2" y="7"
+                      font-size="5" fill="#a78bfa" font-family="JetBrains Mono,monospace"
+                      text-anchor="middle" opacity="0.7">DVT</text>
+              </ng-container>
+
               <ng-container *ngSwitchDefault>
                 <rect x="1" y="1" [attr.width]="CELL-2" [attr.height]="CELL-2"
                       fill="#181d24"
@@ -556,12 +577,18 @@ export class GridCanvasComponent implements OnChanges, AfterViewInit, OnDestroy 
     return `${x2-5},${y-3} ${x2},${y} ${x2-5},${y+3}`;
   }
 
+  arrowPtsDivertSide(): string {
+    const x = CELL / 2, y2 = CELL - 5;
+    return `${x-3},${y2-5} ${x},${y2} ${x+3},${y2-5}`;
+  }
+
   kindColor(kind: string): string {
     return kind === 'conveyor_oneway'   ? '#4ade80'
          : kind === 'conveyor_turn'     ? '#22d3ee'
          : kind === 'package_generator' ? '#86efac'
          : kind === 'package_exit'      ? '#fca5a5'
          : kind === 'merge'             ? '#38bdf8'
+         : kind === 'diverter'          ? '#a78bfa'
          : '#3d4652';
   }
 

--- a/Sources/Stockflow.Console/src/app/features/palette/palette.component.ts
+++ b/Sources/Stockflow.Console/src/app/features/palette/palette.component.ts
@@ -219,7 +219,7 @@ export class PaletteComponent {
 
   get isConveyor(): boolean {
     const kind = this.selectedItem?.kind;
-    return kind === 'conveyor_oneway' || kind === 'conveyor_turn' || kind === 'merge';
+    return kind === 'conveyor_oneway' || kind === 'conveyor_turn' || kind === 'merge' || kind === 'diverter';
   }
 
   select(it: PaletteItem): void {

--- a/Sources/Stockflow.Protocol/Messages/SharedTypes.cs
+++ b/Sources/Stockflow.Protocol/Messages/SharedTypes.cs
@@ -33,6 +33,7 @@ public static class ComponentKinds
     public const string PackageGenerator = "package_generator";
     public const string PackageExit      = "package_exit";
     public const string MergeLogic       = "merge";
+    public const string DiverterLogic    = "diverter";
 }
 
 /// <summary>

--- a/Sources/Stockflow.Simulation/Commands/PlaceComponentCommand.cs
+++ b/Sources/Stockflow.Simulation/Commands/PlaceComponentCommand.cs
@@ -37,4 +37,10 @@ public sealed record PlaceMergeLogicCommand(
     float     Speed = 1f
 ) : ICommand;
 
+public sealed record PlaceDiverterLogicCommand(
+    GridCoord Position,
+    Direction Facing,
+    float     Speed = 1f
+) : ICommand;
+
 public sealed record RemoveComponentCommand(int ComponentId) : ICommand;

--- a/Sources/Stockflow.Simulation/Component/ComponentSchemaRegistry.cs
+++ b/Sources/Stockflow.Simulation/Component/ComponentSchemaRegistry.cs
@@ -14,6 +14,7 @@ public static class ComponentSchemaRegistry
         ["package_generator"] = PackageGenerator.Schema,
         ["package_exit"]      = PackageExit.Schema,
         ["merge"]             = MergeLogic.Schema,
+        ["diverter"]          = DiverterLogic.Schema,
     };
 
     public static IReadOnlyDictionary<string, IReadOnlyList<PropertySchema>> GetAll() => _schemas;

--- a/Sources/Stockflow.Simulation/Component/ComponentType.cs
+++ b/Sources/Stockflow.Simulation/Component/ComponentType.cs
@@ -7,4 +7,5 @@ public enum ComponentType
     PackageGenerator,
     PackageExit,
     MergeLogic,
+    DiverterLogic,
 }

--- a/Sources/Stockflow.Simulation/Component/DiverterLogic.cs
+++ b/Sources/Stockflow.Simulation/Component/DiverterLogic.cs
@@ -1,0 +1,113 @@
+using Stockflow.Simulation.Entity;
+using Stockflow.Simulation.Grid;
+using Stockflow.Simulation.Modules;
+using Stockflow.Simulation.Routing;
+
+namespace Stockflow.Simulation.Component;
+
+public class DiverterLogic : ISimComponent
+{
+    public  int                             Id       { get; }
+    public  GridCoord                       Position { get; }
+    public  Direction                       Facing   { get; }
+    public  ComponentType                   Type     => ComponentType.DiverterLogic;
+    public  IReadOnlyList<IComponentModule> Modules  { get; }
+    public  SimEntity?                      Occupant { get; private set; }
+    public  IReadOnlyList<Port>             Ports    { get; }
+    public  float                           Speed    { get; set; }
+    public  RoutingGraph                    Graph    { get; }
+
+    private readonly Port   _inPort;
+    private readonly Port   _outPort0;  // dritto
+    private readonly Port   _outPort1;  // laterale destra
+
+    private static readonly PortId _portIn   = new(0);
+    private static readonly PortId _portOut0 = new(1);
+    private static readonly PortId _portOut1 = new(2);
+
+    private PortId _activeOut;
+
+    public DiverterLogic(int id, GridCoord position, Direction facing, float speed,
+                         RoutingGraph graph, IReadOnlyList<IComponentModule>? modules = null)
+    {
+        Id         = id;
+        Position   = position;
+        Facing     = facing;
+        Speed      = speed;
+        Graph      = graph;
+        Modules    = modules ?? [];
+        _activeOut = _portOut0;
+
+        _inPort   = new(_portIn,   Position + facing.Opposite().ToOffset(),  PortDirection.In);
+        _outPort0 = new(_portOut0, Position + facing.ToOffset(),              PortDirection.Out);
+        _outPort1 = new(_portOut1, Position + facing.RotateCW().ToOffset(),   PortDirection.Out);
+        Ports     = [_inPort, _outPort0, _outPort1];
+    }
+
+    // --- ConfigSchema ---
+
+    public static readonly PropertySchema[] Schema =
+    [
+        new("speed", "Speed (m/s)", PropertyType.Float, DefaultValue: "1", Min: "0.01", Max: "10"),
+    ];
+
+    public IReadOnlyList<PropertySchema> ConfigSchema => Schema;
+
+    public string? ApplyConfig(IReadOnlyDictionary<string, string> properties)
+    {
+        foreach (var (key, value) in properties)
+        {
+            var schema = Schema.FirstOrDefault(s => s.Key == key);
+            if (schema is null || schema.IsReadOnly) continue;
+
+            var error = schema.Validate(value);
+            if (error is not null) return error;
+
+            if (key == "speed")
+                Speed = float.Parse(value, System.Globalization.CultureInfo.InvariantCulture);
+        }
+        return null;
+    }
+
+    public Dictionary<string, string> ExportProperties() => new()
+    {
+        ["speed"] = Speed.ToString("F3"),
+    };
+
+    public void Tick(float deltaTime)
+    {
+        if (Occupant == null) return;
+
+        if (Occupant.Progress < 1.0f)
+        {
+            Occupant.Progress += Speed * deltaTime;
+            return;
+        }
+
+        var next = Graph.GetNext(this, _activeOut);
+        if (next == null) return;
+
+        if (next.Value.To.TryAccept(Occupant, next.Value.ToPort))
+        {
+            foreach (var module in Modules)
+                module.OnEntityExit(Occupant);
+            Occupant   = null;
+            _activeOut = _activeOut == _portOut0 ? _portOut1 : _portOut0;
+        }
+    }
+
+    public bool TryAccept(SimEntity entity, PortId fromPort)
+    {
+        if (Occupant != null) return false;
+
+        Occupant                = entity;
+        entity.CurrentComponent = this;
+        entity.CurrentPort      = fromPort;
+        entity.Progress         = 0.0f;
+
+        foreach (var module in Modules)
+            module.OnEntityEnter(entity);
+
+        return true;
+    }
+}

--- a/Sources/Stockflow.Simulation/Component/DiverterLogic.cs
+++ b/Sources/Stockflow.Simulation/Component/DiverterLogic.cs
@@ -16,32 +16,34 @@ public class DiverterLogic : ISimComponent
     public  IReadOnlyList<Port>             Ports    { get; }
     public  float                           Speed    { get; set; }
     public  RoutingGraph                    Graph    { get; }
+    public  IRoutingRule                    Rule     { get; }
 
-    private readonly Port   _inPort;
-    private readonly Port   _outPort0;  // dritto
-    private readonly Port   _outPort1;  // laterale destra
+    private readonly Port    _inPort;
+    private readonly Port    _outPort0;  // dritto
+    private readonly Port    _outPort1;  // laterale destra
+    private readonly PortId[] _outputPorts;
 
     private static readonly PortId _portIn   = new(0);
     private static readonly PortId _portOut0 = new(1);
     private static readonly PortId _portOut1 = new(2);
 
-    private PortId _activeOut;
-
     public DiverterLogic(int id, GridCoord position, Direction facing, float speed,
-                         RoutingGraph graph, IReadOnlyList<IComponentModule>? modules = null)
+                         RoutingGraph graph, IRoutingRule? rule = null,
+                         IReadOnlyList<IComponentModule>? modules = null)
     {
-        Id         = id;
-        Position   = position;
-        Facing     = facing;
-        Speed      = speed;
-        Graph      = graph;
-        Modules    = modules ?? [];
-        _activeOut = _portOut0;
+        Id      = id;
+        Position = position;
+        Facing   = facing;
+        Speed    = speed;
+        Graph    = graph;
+        Rule     = rule ?? new RoundRobinRoutingRule();
+        Modules  = modules ?? [];
 
-        _inPort   = new(_portIn,   Position + facing.Opposite().ToOffset(),  PortDirection.In);
-        _outPort0 = new(_portOut0, Position + facing.ToOffset(),              PortDirection.Out);
-        _outPort1 = new(_portOut1, Position + facing.RotateCW().ToOffset(),   PortDirection.Out);
-        Ports     = [_inPort, _outPort0, _outPort1];
+        _inPort      = new(_portIn,   Position + facing.Opposite().ToOffset(), PortDirection.In);
+        _outPort0    = new(_portOut0, Position + facing.ToOffset(),             PortDirection.Out);
+        _outPort1    = new(_portOut1, Position + facing.RotateCW().ToOffset(),  PortDirection.Out);
+        _outputPorts = [_portOut0, _portOut1];
+        Ports        = [_inPort, _outPort0, _outPort1];
     }
 
     // --- ConfigSchema ---
@@ -84,15 +86,16 @@ public class DiverterLogic : ISimComponent
             return;
         }
 
-        var next = Graph.GetNext(this, _activeOut);
+        var targetPort = Rule.SelectOutput(Occupant, _outputPorts);
+        var next       = Graph.GetNext(this, targetPort);
         if (next == null) return;
 
         if (next.Value.To.TryAccept(Occupant, next.Value.ToPort))
         {
             foreach (var module in Modules)
                 module.OnEntityExit(Occupant);
-            Occupant   = null;
-            _activeOut = _activeOut == _portOut0 ? _portOut1 : _portOut0;
+            Rule.OnTransferSucceeded(targetPort);
+            Occupant = null;
         }
     }
 

--- a/Sources/Stockflow.Simulation/Component/DiverterLogic.cs
+++ b/Sources/Stockflow.Simulation/Component/DiverterLogic.cs
@@ -16,7 +16,7 @@ public class DiverterLogic : ISimComponent
     public  IReadOnlyList<Port>             Ports    { get; }
     public  float                           Speed    { get; set; }
     public  RoutingGraph                    Graph    { get; }
-    public  IRoutingRule                    Rule     { get; }
+    public  IRoutingRule                    Rule     { get; private set; }
 
     private readonly Port    _inPort;
     private readonly Port    _outPort0;  // dritto
@@ -50,7 +50,9 @@ public class DiverterLogic : ISimComponent
 
     public static readonly PropertySchema[] Schema =
     [
-        new("speed", "Speed (m/s)", PropertyType.Float, DefaultValue: "1", Min: "0.01", Max: "10"),
+        new("speed",   "Speed (m/s)",  PropertyType.Float, DefaultValue: "1",                       Min: "0.01", Max: "10"),
+        new("routing", "Routing Rule", PropertyType.Enum,  DefaultValue: RoutingRuleFactory.RoundRobin,
+            EnumValues: RoutingRuleFactory.AvailableRules),
     ];
 
     public IReadOnlyList<PropertySchema> ConfigSchema => Schema;
@@ -65,15 +67,25 @@ public class DiverterLogic : ISimComponent
             var error = schema.Validate(value);
             if (error is not null) return error;
 
-            if (key == "speed")
-                Speed = float.Parse(value, System.Globalization.CultureInfo.InvariantCulture);
+            switch (key)
+            {
+                case "speed":
+                    Speed = float.Parse(value, System.Globalization.CultureInfo.InvariantCulture);
+                    break;
+                case "routing":
+                    var newKey = value.ToLowerInvariant();
+                    if (RoutingRuleFactory.KeyOf(Rule) != newKey)
+                        Rule = RoutingRuleFactory.Create(newKey);
+                    break;
+            }
         }
         return null;
     }
 
     public Dictionary<string, string> ExportProperties() => new()
     {
-        ["speed"] = Speed.ToString("F3"),
+        ["speed"]   = Speed.ToString("F3"),
+        ["routing"] = RoutingRuleFactory.KeyOf(Rule),
     };
 
     public void Tick(float deltaTime)

--- a/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
+++ b/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
@@ -50,6 +50,11 @@ public class SimulationEngine
                 var x = (PlaceMergeLogicCommand)c;
                 return new MergeLogic(id, x.Position, x.Facing, x.Mode, x.Speed, Graph);
             },
+            [typeof(PlaceDiverterLogicCommand)] = (c, id) =>
+            {
+                var x = (PlaceDiverterLogicCommand)c;
+                return new DiverterLogic(id, x.Position, x.Facing, x.Speed, Graph);
+            },
         };
     }
 

--- a/Sources/Stockflow.Simulation/Routing/IRoutingRule.cs
+++ b/Sources/Stockflow.Simulation/Routing/IRoutingRule.cs
@@ -1,0 +1,27 @@
+using Stockflow.Simulation.Component;
+using Stockflow.Simulation.Entity;
+
+namespace Stockflow.Simulation.Routing;
+
+/// <summary>
+/// Decides which output port a diverter (or similar 1-to-N component) should use
+/// for a given entity. Implementations encapsulate routing strategies such as
+/// round-robin, SKU-based, destination-based, or minimum-load.
+/// </summary>
+public interface IRoutingRule
+{
+    /// <summary>
+    /// Returns the PortId the entity should be sent to.
+    /// Called every tick while the entity is ready to transfer (Progress >= 1).
+    /// The rule must not mutate internal state here — state advances only via
+    /// <see cref="OnTransferSucceeded"/>.
+    /// </summary>
+    PortId SelectOutput(SimEntity entity, IReadOnlyList<PortId> outputPorts);
+
+    /// <summary>
+    /// Called by the component after a successful transfer to <paramref name="usedPort"/>.
+    /// The rule uses this callback to advance its internal state (e.g. increment the
+    /// round-robin index).
+    /// </summary>
+    void OnTransferSucceeded(PortId usedPort);
+}

--- a/Sources/Stockflow.Simulation/Routing/RoundRobinRoutingRule.cs
+++ b/Sources/Stockflow.Simulation/Routing/RoundRobinRoutingRule.cs
@@ -1,0 +1,20 @@
+using Stockflow.Simulation.Component;
+using Stockflow.Simulation.Entity;
+
+namespace Stockflow.Simulation.Routing;
+
+/// <summary>
+/// Routes entities to output ports in strict rotation order, regardless of entity
+/// properties. After each successful transfer the index advances; blocked outputs
+/// do not cause skipping — the entity waits until its target port is free.
+/// </summary>
+public sealed class RoundRobinRoutingRule : IRoutingRule
+{
+    private int _index;
+
+    public PortId SelectOutput(SimEntity entity, IReadOnlyList<PortId> outputPorts)
+        => outputPorts[_index % outputPorts.Count];
+
+    public void OnTransferSucceeded(PortId usedPort)
+        => _index++;
+}

--- a/Sources/Stockflow.Simulation/Routing/RoutingRuleFactory.cs
+++ b/Sources/Stockflow.Simulation/Routing/RoutingRuleFactory.cs
@@ -1,0 +1,26 @@
+namespace Stockflow.Simulation.Routing;
+
+/// <summary>
+/// Maps the wire/string form of a routing strategy (used in <c>ComponentState.Properties</c>
+/// and in <c>PropertySchema.EnumValues</c>) to its concrete <see cref="IRoutingRule"/>
+/// implementation. New strategies must register both directions here.
+/// </summary>
+public static class RoutingRuleFactory
+{
+    public const string RoundRobin = "round_robin";
+
+    public static readonly string[] AvailableRules = [RoundRobin];
+
+    public static IRoutingRule Create(string key) => key.ToLowerInvariant() switch
+    {
+        RoundRobin => new RoundRobinRoutingRule(),
+        _          => throw new ArgumentException($"Unknown routing rule '{key}'", nameof(key)),
+    };
+
+    public static string KeyOf(IRoutingRule rule) => rule switch
+    {
+        RoundRobinRoutingRule => RoundRobin,
+        _                     => throw new ArgumentException(
+                                     $"Routing rule type '{rule.GetType().Name}' is not registered in the factory"),
+    };
+}

--- a/Sources/Stockflow.Tests.Simulation/DiverterLogicTests.cs
+++ b/Sources/Stockflow.Tests.Simulation/DiverterLogicTests.cs
@@ -167,4 +167,73 @@ public class DiverterLogicTests
         // Output attivo (port1) è bloccato → l'entità resta sul diverter
         Assert.Same(e1, diverter.Occupant);
     }
+
+    // ── Schema / ApplyConfig / ExportProperties ──
+
+    [Fact]
+    public void Schema_ExposesRoutingAsConfigurableEnum()
+    {
+        var routing = DiverterLogic.Schema.Single(p => p.Key == "routing");
+
+        Assert.Equal(PropertyType.Enum, routing.Type);
+        Assert.False(routing.IsReadOnly);
+        Assert.Contains(RoutingRuleFactory.RoundRobin, routing.EnumValues!);
+        Assert.Equal(RoutingRuleFactory.RoundRobin, routing.DefaultValue);
+    }
+
+    [Fact]
+    public void ExportProperties_IncludesRoutingKey()
+    {
+        var diverter = MakeDiverter();
+
+        var exported = diverter.ExportProperties();
+
+        Assert.Equal(RoutingRuleFactory.RoundRobin, exported["routing"]);
+    }
+
+    [Fact]
+    public void ApplyConfig_AcceptsKnownRoutingRule()
+    {
+        var diverter = MakeDiverter();
+
+        var error = diverter.ApplyConfig(new Dictionary<string, string>
+        {
+            ["routing"] = RoutingRuleFactory.RoundRobin,
+        });
+
+        Assert.Null(error);
+        Assert.IsType<RoundRobinRoutingRule>(diverter.Rule);
+    }
+
+    [Fact]
+    public void ApplyConfig_RejectsUnknownRoutingRule()
+    {
+        var diverter = MakeDiverter();
+        var original = diverter.Rule;
+
+        var error = diverter.ApplyConfig(new Dictionary<string, string>
+        {
+            ["routing"] = "minimum_load",
+        });
+
+        Assert.NotNull(error);
+        Assert.Same(original, diverter.Rule);   // unchanged on validation failure
+    }
+
+    [Fact]
+    public void ApplyConfig_SameRoutingRule_PreservesInternalState()
+    {
+        // Reapplying the same strategy must NOT reset the rule (e.g. the round-robin counter).
+        var graph    = new RoutingGraph();
+        var diverter = MakeDiverter(graph);
+        var originalRule = diverter.Rule;
+
+        var error = diverter.ApplyConfig(new Dictionary<string, string>
+        {
+            ["routing"] = RoutingRuleFactory.RoundRobin,
+        });
+
+        Assert.Null(error);
+        Assert.Same(originalRule, diverter.Rule);
+    }
 }

--- a/Sources/Stockflow.Tests.Simulation/DiverterLogicTests.cs
+++ b/Sources/Stockflow.Tests.Simulation/DiverterLogicTests.cs
@@ -1,0 +1,170 @@
+using Stockflow.Simulation.Component;
+using Stockflow.Simulation.Entity;
+using Stockflow.Simulation.Grid;
+using Stockflow.Simulation.Routing;
+
+namespace Stockflow.Tests.Simulation;
+
+public class DiverterLogicTests
+{
+    private static DiverterLogic MakeDiverter(RoutingGraph? graph = null)
+        => new(1, new GridCoord(0, 0), Direction.North, 1f, graph ?? new RoutingGraph());
+
+    [Fact]
+    public void TryAccept_EmptySlot_AcceptsEntity()
+    {
+        var diverter = MakeDiverter();
+        var entity   = new EntityManager().Spawn("A", 1f, 1f, 0f, diverter, new PortId(0));
+
+        Assert.True(diverter.TryAccept(entity, new PortId(0)));
+        Assert.Same(diverter, entity.CurrentComponent);
+        Assert.Equal(0f, entity.Progress);
+    }
+
+    [Fact]
+    public void TryAccept_OccupiedSlot_ReturnsFalse()
+    {
+        var diverter = MakeDiverter();
+        var mgr      = new EntityManager();
+        var e1       = mgr.Spawn("A", 1f, 1f, 0f, diverter, new PortId(0));
+        var e2       = mgr.Spawn("B", 1f, 1f, 0f, diverter, new PortId(0));
+        diverter.TryAccept(e1, new PortId(0));
+
+        Assert.False(diverter.TryAccept(e2, new PortId(0)));
+    }
+
+    [Fact]
+    public void Ports_FacingNorth_CorrectPositions()
+    {
+        // Facing=North, Position=(0,0)
+        // InPort  (0): South = (0, 1)
+        // OutPort0(1): North = (0,-1)  — dritto
+        // OutPort1(2): East  = (1, 0)  — laterale destra
+        var diverter = MakeDiverter();
+
+        Assert.Equal(new GridCoord(0,  1), diverter.Ports[0].Position);
+        Assert.Equal(PortDirection.In,    diverter.Ports[0].Direction);
+
+        Assert.Equal(new GridCoord(0, -1), diverter.Ports[1].Position);
+        Assert.Equal(PortDirection.Out,    diverter.Ports[1].Direction);
+
+        Assert.Equal(new GridCoord(1,  0), diverter.Ports[2].Position);
+        Assert.Equal(PortDirection.Out,    diverter.Ports[2].Direction);
+    }
+
+    [Fact]
+    public void Tick_ProgressAdvances()
+    {
+        var diverter = MakeDiverter();
+        var entity   = new EntityManager().Spawn("A", 1f, 1f, 0f, diverter, new PortId(0));
+        diverter.TryAccept(entity, new PortId(0));
+
+        diverter.Tick(0.5f);
+
+        Assert.Equal(0.5f, entity.Progress);
+    }
+
+    [Fact]
+    public void Tick_NoNext_EntityStays()
+    {
+        var diverter = MakeDiverter();
+        var entity   = new EntityManager().Spawn("A", 1f, 1f, 0f, diverter, new PortId(0));
+        diverter.TryAccept(entity, new PortId(0));
+        diverter.Tick(1f);
+        diverter.Tick(0f);
+
+        Assert.Same(entity, diverter.Occupant);
+    }
+
+    [Fact]
+    public void RoundRobin_FirstEntity_GoesToOutPort0()
+    {
+        var graph    = new RoutingGraph();
+        var diverter = MakeDiverter(graph);
+        var mgr      = new EntityManager();
+
+        var exit0 = new PackageExit(2, new GridCoord(0, -1), Direction.North, mgr);
+        var exit1 = new PackageExit(3, new GridCoord(1,  0), Direction.East,  mgr);
+        graph.Connect(diverter, new PortId(1), exit0, new PortId(0));
+        graph.Connect(diverter, new PortId(2), exit1, new PortId(0));
+
+        var e1 = mgr.Spawn("A", 1f, 1f, 0f, diverter, new PortId(0));
+        diverter.TryAccept(e1, new PortId(0));
+        diverter.Tick(1f);
+        diverter.Tick(0f);
+
+        Assert.Null(diverter.Occupant);
+        Assert.Same(exit0, e1.CurrentComponent);
+    }
+
+    [Fact]
+    public void RoundRobin_SecondEntity_GoesToOutPort1()
+    {
+        var graph    = new RoutingGraph();
+        var diverter = MakeDiverter(graph);
+        var mgr      = new EntityManager();
+
+        var exit0 = new PackageExit(2, new GridCoord(0, -1), Direction.North, mgr);
+        var exit1 = new PackageExit(3, new GridCoord(1,  0), Direction.East,  mgr);
+        graph.Connect(diverter, new PortId(1), exit0, new PortId(0));
+        graph.Connect(diverter, new PortId(2), exit1, new PortId(0));
+
+        var e1 = mgr.Spawn("A", 1f, 1f, 0f, diverter, new PortId(0));
+        diverter.TryAccept(e1, new PortId(0));
+        diverter.Tick(1f); diverter.Tick(0f);
+
+        var e2 = mgr.Spawn("B", 1f, 1f, 0f, diverter, new PortId(0));
+        diverter.TryAccept(e2, new PortId(0));
+        diverter.Tick(1f); diverter.Tick(0f);
+
+        Assert.Null(diverter.Occupant);
+        Assert.Same(exit1, e2.CurrentComponent);
+    }
+
+    [Fact]
+    public void RoundRobin_ThirdEntity_GoesToOutPort0Again()
+    {
+        var graph    = new RoutingGraph();
+        var diverter = MakeDiverter(graph);
+        var mgr      = new EntityManager();
+
+        var exit0 = new PackageExit(2, new GridCoord(0, -1), Direction.North, mgr);
+        var exit1 = new PackageExit(3, new GridCoord(1,  0), Direction.East,  mgr);
+        graph.Connect(diverter, new PortId(1), exit0, new PortId(0));
+        graph.Connect(diverter, new PortId(2), exit1, new PortId(0));
+
+        for (int i = 0; i < 3; i++)
+        {
+            var e = mgr.Spawn($"E{i}", 1f, 1f, 0f, diverter, new PortId(0));
+            diverter.TryAccept(e, new PortId(0));
+            diverter.Tick(1f); diverter.Tick(0f);
+            exit0.Tick(0f); exit1.Tick(0f);
+        }
+
+        Assert.Equal(2, exit0.TotalProcessed);
+        Assert.Equal(1, exit1.TotalProcessed);
+    }
+
+    [Fact]
+    public void RoundRobin_BlockedFirstOutput_EntityWaitsAndDoesNotSkip()
+    {
+        var graph    = new RoutingGraph();
+        var diverter = MakeDiverter(graph);
+        var mgr      = new EntityManager();
+
+        // exit0 è collegato ma occupato — usiamo un conveyor già pieno
+        var blocker   = new OneWayConveyor(2, new GridCoord(0, -1), Direction.North, 1f, graph);
+        var occupying = mgr.Spawn("X", 1f, 1f, 0f, blocker, new PortId(0));
+        blocker.TryAccept(occupying, new PortId(0));
+
+        graph.Connect(diverter, new PortId(1), blocker, new PortId(0));
+        // porta 2 non connessa
+
+        var e1 = mgr.Spawn("A", 1f, 1f, 0f, diverter, new PortId(0));
+        diverter.TryAccept(e1, new PortId(0));
+        diverter.Tick(1f); diverter.Tick(0f);
+
+        // Output attivo (port1) è bloccato → l'entità resta sul diverter
+        Assert.Same(e1, diverter.Occupant);
+    }
+}

--- a/Sources/Stockflow.Tests.Simulation/RoundRobinRoutingRuleTests.cs
+++ b/Sources/Stockflow.Tests.Simulation/RoundRobinRoutingRuleTests.cs
@@ -1,0 +1,79 @@
+using Stockflow.Simulation.Component;
+using Stockflow.Simulation.Entity;
+using Stockflow.Simulation.Grid;
+using Stockflow.Simulation.Routing;
+using Stockflow.Tests.Simulation.Helpers;
+
+namespace Stockflow.Tests.Simulation;
+
+public class RoundRobinRoutingRuleTests
+{
+    private static SimEntity MakeEntity()
+    {
+        var stub = new StubComponent();
+        return new EntityManager().Spawn("A", 1f, 1f, 0f, stub, new PortId(0));
+    }
+
+    private static readonly PortId Port1 = new(1);
+    private static readonly PortId Port2 = new(2);
+    private static readonly IReadOnlyList<PortId> TwoPorts = [Port1, Port2];
+
+    [Fact]
+    public void SelectOutput_Initially_ReturnsFirstPort()
+    {
+        var rule   = new RoundRobinRoutingRule();
+        var entity = MakeEntity();
+
+        Assert.Equal(Port1, rule.SelectOutput(entity, TwoPorts));
+    }
+
+    [Fact]
+    public void SelectOutput_BeforeTransferSucceeded_KeepsReturningFirstPort()
+    {
+        var rule   = new RoundRobinRoutingRule();
+        var entity = MakeEntity();
+
+        rule.SelectOutput(entity, TwoPorts);
+        rule.SelectOutput(entity, TwoPorts);
+
+        Assert.Equal(Port1, rule.SelectOutput(entity, TwoPorts));
+    }
+
+    [Fact]
+    public void SelectOutput_AfterOneTransfer_ReturnsSecondPort()
+    {
+        var rule   = new RoundRobinRoutingRule();
+        var entity = MakeEntity();
+
+        rule.SelectOutput(entity, TwoPorts);
+        rule.OnTransferSucceeded(Port1);
+
+        Assert.Equal(Port2, rule.SelectOutput(entity, TwoPorts));
+    }
+
+    [Fact]
+    public void SelectOutput_AfterTwoTransfers_WrapsToFirstPort()
+    {
+        var rule   = new RoundRobinRoutingRule();
+        var entity = MakeEntity();
+
+        rule.OnTransferSucceeded(Port1);
+        rule.OnTransferSucceeded(Port2);
+
+        Assert.Equal(Port1, rule.SelectOutput(entity, TwoPorts));
+    }
+
+    [Fact]
+    public void SelectOutput_EntityIsIgnored_AlwaysRoundRobins()
+    {
+        var rule = new RoundRobinRoutingRule();
+        var mgr  = new EntityManager();
+        var stub = new StubComponent();
+        var e1   = mgr.Spawn("SKU-A", 1f, 1f, 0f, stub, new PortId(0));
+        var e2   = mgr.Spawn("SKU-B", 2f, 2f, 0f, stub, new PortId(0));
+
+        Assert.Equal(Port1, rule.SelectOutput(e1, TwoPorts));
+        rule.OnTransferSucceeded(Port1);
+        Assert.Equal(Port2, rule.SelectOutput(e2, TwoPorts));
+    }
+}

--- a/Sources/Stockflow.Tests.Simulation/RoutingRuleFactoryTests.cs
+++ b/Sources/Stockflow.Tests.Simulation/RoutingRuleFactoryTests.cs
@@ -1,0 +1,51 @@
+using Stockflow.Simulation.Routing;
+
+namespace Stockflow.Tests.Simulation;
+
+public class RoutingRuleFactoryTests
+{
+    [Fact]
+    public void Create_RoundRobin_ReturnsRoundRobinRule()
+    {
+        var rule = RoutingRuleFactory.Create(RoutingRuleFactory.RoundRobin);
+
+        Assert.IsType<RoundRobinRoutingRule>(rule);
+    }
+
+    [Fact]
+    public void Create_IsCaseInsensitive()
+    {
+        var rule = RoutingRuleFactory.Create("ROUND_ROBIN");
+
+        Assert.IsType<RoundRobinRoutingRule>(rule);
+    }
+
+    [Fact]
+    public void Create_UnknownKey_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => RoutingRuleFactory.Create("by_destination"));
+    }
+
+    [Fact]
+    public void KeyOf_RoundRobinRule_ReturnsRoundRobin()
+    {
+        Assert.Equal(RoutingRuleFactory.RoundRobin,
+                     RoutingRuleFactory.KeyOf(new RoundRobinRoutingRule()));
+    }
+
+    [Fact]
+    public void AvailableRules_ContainsAtLeastRoundRobin()
+    {
+        Assert.Contains(RoutingRuleFactory.RoundRobin, RoutingRuleFactory.AvailableRules);
+    }
+
+    [Fact]
+    public void AvailableRules_AllRoundTripThroughCreateAndKeyOf()
+    {
+        foreach (var key in RoutingRuleFactory.AvailableRules)
+        {
+            var rule = RoutingRuleFactory.Create(key);
+            Assert.Equal(key, RoutingRuleFactory.KeyOf(rule));
+        }
+    }
+}

--- a/Sources/Stockflow.Webserver/Controllers/SimulationController.cs
+++ b/Sources/Stockflow.Webserver/Controllers/SimulationController.cs
@@ -132,6 +132,7 @@ public sealed class SimulationController(
                 dir,
                 req.Mode == "priority" ? MergeMode.Priority : MergeMode.Alternating,
                 req.Speed ?? 1f),
+            ComponentKinds.DiverterLogic => new PlaceDiverterLogicCommand(pos, dir, req.Speed ?? 1f),
             _ => null,
         };
 

--- a/Sources/Stockflow.Webserver/Serialization/ComponentSerializer.cs
+++ b/Sources/Stockflow.Webserver/Serialization/ComponentSerializer.cs
@@ -18,6 +18,7 @@ public static class ComponentSerializer
         SimComponentType.PackageGenerator => ComponentKinds.PackageGenerator,
         SimComponentType.PackageExit      => ComponentKinds.PackageExit,
         SimComponentType.MergeLogic       => ComponentKinds.MergeLogic,
+        SimComponentType.DiverterLogic    => ComponentKinds.DiverterLogic,
         _                                 => type.ToString().ToLowerInvariant(),
     };
 


### PR DESCRIPTION
## Summary

- Nuovo componente `DiverterLogic` (1×1, 1 ingresso, 2 uscite: dritto + laterale destra) con costo 400 e hotkey 4, allineato a GDD §4.1.
- Astrazione `IRoutingRule` + implementazione `RoundRobinRoutingRule` nella cartella `Routing/`, predisposta per future strategie (SKU, destinazione, carico minimo — issue di follow-up).
- Strategia di routing **configurabile a runtime** via schema-driven UI: nuova proprietà enum `routing` su `DiverterLogic.Schema`, factory `RoutingRuleFactory` che mappa stringa ⇄ rule, `ApplyConfig` swap-on-change (preserva lo stato interno della rule su no-op).
- Integrazione completa: comando `PlaceDiverterLogicCommand`, `ComponentType.DiverterLogic`, `ComponentSchemaRegistry`, `ComponentSerializer`, controller REST, icona SVG sulla console Angular (`live=true`).

## Coerenza con la documentazione

Il GDD richiede esplicitamente regole di routing **configurabili dal giocatore** (GDD §4.1, §13). Con questa PR la configurabilità è reale: il client riceve lo schema, espone il dropdown automaticamente nell'inspector (rendering enum esistente) e ribattezza la rule via `configure` command. Le 3 strategie restanti (SKU, destinazione, carico minimo) richiedono solo nuove `IRoutingRule` + una riga nel factory, senza modifiche a `DiverterLogic`.

## Cosa NON è incluso (follow-up suggeriti)

- Strategie `sku`, `by_destination`, `minimum_load` (richiedono anche issue #28 per `DestinationComponent`).
- `DivertSide { Left, Right }` — al momento l'uscita laterale è hard-coded a destra.
- Modalità `skip-on-block` (con un'uscita bloccata l'entità attende anziché ripiegare sull'altra porta).
- Test su tutti e 4 i `Direction` per le posizioni delle porte (attualmente solo `North`).
- Aggiornamento di `Docs/SIMULATION_ENGINE_v0.1.md` con la sezione `DiverterLogic` + `IRoutingRule`.

## Test plan

- [ ] `dotnet build Stockflow.slnx` senza warning nuovi.
- [ ] `dotnet test Sources/Stockflow.Tests.Simulation/` — 15 nuovi test passano (`DiverterLogicTests` x10, `RoundRobinRoutingRuleTests` x5, `RoutingRuleFactoryTests` x6).
- [ ] Avvio webserver, piazzamento di un Diverter dalla console Angular: l'icona viola appare, l'inspector mostra `Speed` e `Routing Rule` (dropdown con `round_robin`).
- [ ] Configura due exit a valle dei due output, lancia 3 pacchi: verifica che vadano alternati (output0, output1, output0).
- [ ] Cambia il valore di `routing` dall'inspector e applica: nessun errore, lo stato del round-robin non si resetta se la chiave è la stessa.
- [ ] Invia un valore `routing=invalid` via REST: il server risponde con errore di validazione e la rule corrente resta invariata.


---
_Generated by [Claude Code](https://claude.ai/code/session_01S3Dd1Q7y3CprgfZxn2uXtM)_