### PR TITLE
fix(simulation): 13 bug fix — C1-C5, M1-M5, L1-L3

### DIFF
--- a/Docs/SIMULATION_ENGINE_v0.1.md
+++ b/Docs/SIMULATION_ENGINE_v0.1.md
@@ -455,26 +455,27 @@ Helper condiviso: `Helpers/StubComponent` — implementazione minimale di `ISimC
 
 ---
 
-## Stato attuale e gap noti
+## Stato attuale (aggiornato 2026-05-27)
 
 | Componente | Stato |
 |---|---|
-| `SimulationEngine` + tick loop | ✅ Implementato |
-| `SimulationClock` (`SimulatedTime`, `TimeScale`, `IsLiveMode`, `Advance`) | ✅ Implementato (#5) |
-| `GridManager` + `Cell` + `GridCoord` | ✅ Implementato |
-| `ISimComponent` + `OneWayConveyor` | ✅ Implementato |
-| `ConveyorTurn` + `TurnSide` | ✅ Implementato (#20) |
-| `RoutingGraph` + `Connection` | ✅ Implementato |
-| `ICommand` + `CommandResult` | ✅ Implementati |
-| `StateDelta` (componenti + entità + eventi) | ✅ Implementata (#6) |
-| `SimulationEvent` (`EntityTransferred`, `ConveyorJammed`) | ✅ Dichiarata; non ancora emessa nel tick |
-| `IComponentModule` (interfaccia) | ✅ Implementata; `OnTick` non ancora invocato |
-| `SimEntity` + `EntityStatus` | ✅ Implementati (#6) |
-| `EntityState` (snapshot rete) | ✅ Implementato (#6) |
-| `EntityManager` (CRUD + object pool) | ✅ Implementato (#6) |
-| Entità in `SimulationState` | ✅ Implementato (#6) |
-| Unit test `Stockflow.Tests.Simulation` | ✅ Implementati (#20) — 38 test, tutti passanti |
-| Delta completo (posizioni aggiornate tick-by-tick) | Parziale — issue #8 |
-| Emissione `SimulationEvent` durante il tick | Mancante — da collegare a #8 |
-| Comandi concreti | Mancanti — issue #33 |
-| Logica routing con `DestinationComponent` | Mancante — issue #28 |
+| `SimulationEngine` + tick loop | ✅ |
+| `SimulationClock` (SimulatedTime, TimeScale, IsLiveMode esplicito) | ✅ |
+| `GridManager` + `Cell` + `GridCoord` | ✅ |
+| `ISimComponent` + `OneWayConveyor` | ✅ |
+| `ConveyorTurn` + `TurnSide` | ✅ |
+| `MergeLogic` (Alternating/Priority, Side, starvation time-based) | ✅ |
+| `DiverterLogic` (RoundRobin, Side, SetFacing) | ✅ |
+| `PackageGenerator` + `PackageExit` (shared clock via getSimTime) | ✅ |
+| `RoutingGraph` + `Connection` (Connect guard) | ✅ |
+| `ICommand` + comandi concreti (Place/Remove/Configure/LoadScenario) | ✅ |
+| `StateDelta` completa (componenti + entità + eventi) | ✅ |
+| `SimulationEvent` (EntityTransferred, ConveyorJammed) emessa nel tick | ✅ |
+| Schema-driven config (`ConfigSchema`, `ApplyConfig`, `ExportProperties`) | ✅ |
+| `IComponentModule.OnTick` invocato dall'engine | ✅ |
+| `SetFacing` runtime su OneWayConveyor, ConveyorTurn, DiverterLogic | ✅ |
+| Unit test | ✅ 153 test, tutti passanti |
+| `AccumulatorLogic` | ⬜ |
+| `PathFinder` su `RoutingGraph` | ⬜ |
+| `Scaffalature` + `StackerCraneLogic` | ⬜ |
+| `MissionController` + `OrderManager` | ⬜ |

--- a/Sources/Stockflow.Simulation/Component/ConveyorTurn.cs
+++ b/Sources/Stockflow.Simulation/Component/ConveyorTurn.cs
@@ -10,13 +10,13 @@ public class ConveyorTurn : ISimComponent
 {
     public  int                             Id       { get; }
     public  GridCoord                       Position { get; }
-    public  Direction                       Facing   { get; }
+    public  Direction                       Facing   { get; private set; }
     public  ComponentType                   Type     => ComponentType.ConveyorTurn;
     public  IReadOnlyList<IComponentModule> Modules  { get; }
     public  SimEntity?                      Occupant { get; private set; }
-    private Port                            InPort   { get; }
-    private Port                            OutPort  { get; }
-    public  IReadOnlyList<Port>             Ports    { get; }
+    private Port                            InPort   { get; set; }
+    private Port                            OutPort  { get; set; }
+    public  IReadOnlyList<Port>             Ports    { get; private set; }
     public  float                           Speed    { get; set; }
     public  TurnSide                        Turn     { get; set; }
     public  RoutingGraph                    Graph    { get; }
@@ -34,11 +34,25 @@ public class ConveyorTurn : ISimComponent
         Speed    = speed;
         Graph    = graph;
         Modules  = modules ?? [];
+        InPort   = default;
+        OutPort  = default;
+        Ports    = [];
+        RebuildPorts();
+    }
 
-        var exitFacing = turn == TurnSide.Right ? facing.RotateCW() : facing.RotateCCW();
-        InPort  = new(new(0), Position + facing.Opposite().ToOffset(), PortDirection.In);
+    private void RebuildPorts()
+    {
+        var exitFacing = Turn == TurnSide.Right ? Facing.RotateCW() : Facing.RotateCCW();
+        InPort  = new(new(0), Position + Facing.Opposite().ToOffset(), PortDirection.In);
         OutPort = new(new(1), Position + exitFacing.ToOffset(),        PortDirection.Out);
         Ports   = [InPort, OutPort];
+    }
+
+    public bool SetFacing(Direction newFacing)
+    {
+        Facing = newFacing;
+        RebuildPorts();
+        return true;
     }
 
     // --- ConfigSchema ---

--- a/Sources/Stockflow.Simulation/Component/ConveyorTurn.cs
+++ b/Sources/Stockflow.Simulation/Component/ConveyorTurn.cs
@@ -1,3 +1,4 @@
+using Stockflow.Simulation.Core;
 using Stockflow.Simulation.Entity;
 using Stockflow.Simulation.Grid;
 using Stockflow.Simulation.Modules;
@@ -19,6 +20,9 @@ public class ConveyorTurn : ISimComponent
     public  float                           Speed    { get; set; }
     public  TurnSide                        Turn     { get; set; }
     public  RoutingGraph                    Graph    { get; }
+
+    private readonly List<SimulationEvent>  _pendingEvents = new();
+    public  IReadOnlyList<SimulationEvent>  PendingEvents  => _pendingEvents;
 
     public ConveyorTurn(int id, GridCoord position, Direction facing, TurnSide turn, float speed,
                         RoutingGraph graph, IReadOnlyList<IComponentModule>? modules = null)
@@ -79,6 +83,7 @@ public class ConveyorTurn : ISimComponent
 
     public void Tick(float deltaTime)
     {
+        _pendingEvents.Clear();
         if (Occupant == null) return;
         if (Occupant.Progress < 1.0f)
         {
@@ -92,10 +97,34 @@ public class ConveyorTurn : ISimComponent
                 var nextComp = next.Value.To;
                 if (nextComp.TryAccept(Occupant, next.Value.ToPort))
                 {
+                    _pendingEvents.Add(new SimulationEvent
+                    {
+                        Type        = SimulationEventType.EntityTransferred,
+                        EntityId    = Occupant.Id,
+                        ComponentId = Id,
+                    });
                     foreach (var module in Modules)
                         module.OnEntityExit(Occupant);
                     Occupant = null;
                 }
+                else
+                {
+                    _pendingEvents.Add(new SimulationEvent
+                    {
+                        Type        = SimulationEventType.ConveyorJammed,
+                        EntityId    = Occupant.Id,
+                        ComponentId = Id,
+                    });
+                }
+            }
+            else
+            {
+                _pendingEvents.Add(new SimulationEvent
+                {
+                    Type        = SimulationEventType.ConveyorJammed,
+                    EntityId    = Occupant.Id,
+                    ComponentId = Id,
+                });
             }
         }
     }

--- a/Sources/Stockflow.Simulation/Component/ConveyorTurn.cs
+++ b/Sources/Stockflow.Simulation/Component/ConveyorTurn.cs
@@ -82,7 +82,7 @@ public class ConveyorTurn : ISimComponent
         if (Occupant == null) return;
         if (Occupant.Progress < 1.0f)
         {
-            Occupant.Progress += Speed * deltaTime;
+            Occupant.Progress = MathF.Min(Occupant.Progress + Speed * deltaTime, 1.0f);
         }
         else
         {

--- a/Sources/Stockflow.Simulation/Component/DiverterLogic.cs
+++ b/Sources/Stockflow.Simulation/Component/DiverterLogic.cs
@@ -100,7 +100,7 @@ public class DiverterLogic : ISimComponent
 
         if (Occupant.Progress < 1.0f)
         {
-            Occupant.Progress += Speed * deltaTime;
+            Occupant.Progress = MathF.Min(Occupant.Progress + Speed * deltaTime, 1.0f);
             return;
         }
 

--- a/Sources/Stockflow.Simulation/Component/DiverterLogic.cs
+++ b/Sources/Stockflow.Simulation/Component/DiverterLogic.cs
@@ -1,3 +1,4 @@
+using Stockflow.Simulation.Core;
 using Stockflow.Simulation.Entity;
 using Stockflow.Simulation.Grid;
 using Stockflow.Simulation.Modules;
@@ -19,10 +20,13 @@ public class DiverterLogic : ISimComponent
     public  RoutingGraph                    Graph    { get; }
     public  IRoutingRule                    Rule     { get; private set; }
 
-    private readonly Port    _inPort;
-    private readonly Port    _outPort0;  // dritto
-    private readonly Port    _outPort1;  // laterale (sinistra o destra in base a Side)
+    private readonly Port     _inPort;
+    private readonly Port     _outPort0;  // dritto
+    private readonly Port     _outPort1;  // laterale (sinistra o destra in base a Side)
     private readonly PortId[] _outputPorts;
+
+    private readonly List<SimulationEvent> _pendingEvents = new();
+    public  IReadOnlyList<SimulationEvent> PendingEvents  => _pendingEvents;
 
     private static readonly PortId _portIn   = new(0);
     private static readonly PortId _portOut0 = new(1);
@@ -96,6 +100,7 @@ public class DiverterLogic : ISimComponent
 
     public void Tick(float deltaTime)
     {
+        _pendingEvents.Clear();
         if (Occupant == null) return;
 
         if (Occupant.Progress < 1.0f)
@@ -106,14 +111,38 @@ public class DiverterLogic : ISimComponent
 
         var targetPort = Rule.SelectOutput(Occupant, _outputPorts);
         var next       = Graph.GetNext(this, targetPort);
-        if (next == null) return;
+        if (next == null)
+        {
+            _pendingEvents.Add(new SimulationEvent
+            {
+                Type        = SimulationEventType.ConveyorJammed,
+                EntityId    = Occupant.Id,
+                ComponentId = Id,
+            });
+            return;
+        }
 
         if (next.Value.To.TryAccept(Occupant, next.Value.ToPort))
         {
+            _pendingEvents.Add(new SimulationEvent
+            {
+                Type        = SimulationEventType.EntityTransferred,
+                EntityId    = Occupant.Id,
+                ComponentId = Id,
+            });
             foreach (var module in Modules)
                 module.OnEntityExit(Occupant);
             Rule.OnTransferSucceeded(targetPort);
             Occupant = null;
+        }
+        else
+        {
+            _pendingEvents.Add(new SimulationEvent
+            {
+                Type        = SimulationEventType.ConveyorJammed,
+                EntityId    = Occupant.Id,
+                ComponentId = Id,
+            });
         }
     }
 

--- a/Sources/Stockflow.Simulation/Component/DiverterLogic.cs
+++ b/Sources/Stockflow.Simulation/Component/DiverterLogic.cs
@@ -10,19 +10,19 @@ public class DiverterLogic : ISimComponent
 {
     public  int                             Id       { get; }
     public  GridCoord                       Position { get; }
-    public  Direction                       Facing   { get; }
+    public  Direction                       Facing   { get; private set; }
     public  TurnSide                        Side     { get; }
     public  ComponentType                   Type     => ComponentType.DiverterLogic;
     public  IReadOnlyList<IComponentModule> Modules  { get; }
     public  SimEntity?                      Occupant { get; private set; }
-    public  IReadOnlyList<Port>             Ports    { get; }
+    public  IReadOnlyList<Port>             Ports    { get; private set; }
     public  float                           Speed    { get; set; }
     public  RoutingGraph                    Graph    { get; }
     public  IRoutingRule                    Rule     { get; private set; }
 
-    private readonly Port     _inPort;
-    private readonly Port     _outPort0;  // dritto
-    private readonly Port     _outPort1;  // laterale (sinistra o destra in base a Side)
+    private Port     _inPort;
+    private Port     _outPort0;  // dritto
+    private Port     _outPort1;  // laterale (sinistra o destra in base a Side)
     private readonly PortId[] _outputPorts;
 
     private readonly List<SimulationEvent> _pendingEvents = new();
@@ -36,21 +36,36 @@ public class DiverterLogic : ISimComponent
                          RoutingGraph graph, IRoutingRule? rule = null,
                          IReadOnlyList<IComponentModule>? modules = null)
     {
-        Id       = id;
-        Position = position;
-        Facing   = facing;
-        Side     = side;
-        Speed    = speed;
-        Graph    = graph;
-        Rule     = rule ?? new RoundRobinRoutingRule();
-        Modules  = modules ?? [];
-
-        var lateralDir = side == TurnSide.Right ? facing.RotateCW() : facing.RotateCCW();
-        _inPort      = new(_portIn,   Position + facing.Opposite().ToOffset(), PortDirection.In);
-        _outPort0    = new(_portOut0, Position + facing.ToOffset(),             PortDirection.Out);
-        _outPort1    = new(_portOut1, Position + lateralDir.ToOffset(),         PortDirection.Out);
+        Id           = id;
+        Position     = position;
+        Facing       = facing;
+        Side         = side;
+        Speed        = speed;
+        Graph        = graph;
+        Rule         = rule ?? new RoundRobinRoutingRule();
+        Modules      = modules ?? [];
+        _inPort      = default;
+        _outPort0    = default;
+        _outPort1    = default;
         _outputPorts = [_portOut0, _portOut1];
-        Ports        = [_inPort, _outPort0, _outPort1];
+        Ports        = [];
+        RebuildPorts();
+    }
+
+    private void RebuildPorts()
+    {
+        var lateralDir = Side == TurnSide.Right ? Facing.RotateCW() : Facing.RotateCCW();
+        _inPort   = new(_portIn,   Position + Facing.Opposite().ToOffset(), PortDirection.In);
+        _outPort0 = new(_portOut0, Position + Facing.ToOffset(),            PortDirection.Out);
+        _outPort1 = new(_portOut1, Position + lateralDir.ToOffset(),        PortDirection.Out);
+        Ports     = [_inPort, _outPort0, _outPort1];
+    }
+
+    public bool SetFacing(Direction newFacing)
+    {
+        Facing = newFacing;
+        RebuildPorts();
+        return true;
     }
 
     // --- ConfigSchema ---

--- a/Sources/Stockflow.Simulation/Component/ISimComponent.cs
+++ b/Sources/Stockflow.Simulation/Component/ISimComponent.cs
@@ -42,6 +42,12 @@ public interface ISimComponent
     /// </summary>
     Dictionary<string, string> ExportProperties();
 
+    /// <summary>
+    /// Attempts to change the component's facing direction at runtime, rebuilding ports accordingly.
+    /// Returns true if the component supports runtime facing changes (conveyors), false otherwise.
+    /// </summary>
+    bool SetFacing(Direction newFacing);
+
     // Chiamato ogni tick — gestisce logica interna
     // (es. il traslo muove le forche, l'accumulo decide se rilasciare)
     void Tick(float deltaTime);

--- a/Sources/Stockflow.Simulation/Component/ISimComponent.cs
+++ b/Sources/Stockflow.Simulation/Component/ISimComponent.cs
@@ -1,3 +1,4 @@
+using Stockflow.Simulation.Core;
 using Stockflow.Simulation.Entity;
 using Stockflow.Simulation.Grid;
 using Stockflow.Simulation.Modules;
@@ -15,6 +16,8 @@ public interface ISimComponent
     SimEntity?                      Occupant { get; }
     // Porte attraverso cui le entità entrano/escono
     IReadOnlyList<Port> Ports { get; }
+    // Events generated during Tick — drained by SimulationEngine
+    IReadOnlyList<SimulationEvent> PendingEvents { get; }
 
     // --- Schema-driven configuration (Phase 1D) ---
 

--- a/Sources/Stockflow.Simulation/Component/MergeLogic.cs
+++ b/Sources/Stockflow.Simulation/Component/MergeLogic.cs
@@ -114,7 +114,7 @@ public class MergeLogic : ISimComponent
 
         if (Occupant.Progress < 1.0f)
         {
-            Occupant.Progress += Speed * deltaTime;
+            Occupant.Progress = MathF.Min(Occupant.Progress + Speed * deltaTime, 1.0f);
         }
         else
         {

--- a/Sources/Stockflow.Simulation/Component/MergeLogic.cs
+++ b/Sources/Stockflow.Simulation/Component/MergeLogic.cs
@@ -1,3 +1,4 @@
+using Stockflow.Simulation.Core;
 using Stockflow.Simulation.Entity;
 using Stockflow.Simulation.Grid;
 using Stockflow.Simulation.Modules;
@@ -26,6 +27,9 @@ public class MergeLogic : ISimComponent
     private PortId _activePort;
     private float  _stallTime;
     private const float StallSeconds = 1f;
+
+    private readonly List<SimulationEvent> _pendingEvents = new();
+    public  IReadOnlyList<SimulationEvent> PendingEvents  => _pendingEvents;
 
     private static readonly PortId _port0 = new(0);
     private static readonly PortId _port1 = new(1);
@@ -101,6 +105,7 @@ public class MergeLogic : ISimComponent
 
     public void Tick(float deltaTime)
     {
+        _pendingEvents.Clear();
         if (Occupant == null)
         {
             _stallTime += deltaTime;
@@ -121,9 +126,24 @@ public class MergeLogic : ISimComponent
             var next = Graph.GetNext(this, _outPort.Id);
             if (next != null && next.Value.To.TryAccept(Occupant, next.Value.ToPort))
             {
+                _pendingEvents.Add(new SimulationEvent
+                {
+                    Type        = SimulationEventType.EntityTransferred,
+                    EntityId    = Occupant.Id,
+                    ComponentId = Id,
+                });
                 foreach (var module in Modules)
                     module.OnEntityExit(Occupant);
                 Occupant = null;
+            }
+            else
+            {
+                _pendingEvents.Add(new SimulationEvent
+                {
+                    Type        = SimulationEventType.ConveyorJammed,
+                    EntityId    = Occupant.Id,
+                    ComponentId = Id,
+                });
             }
         }
     }

--- a/Sources/Stockflow.Simulation/Component/MergeLogic.cs
+++ b/Sources/Stockflow.Simulation/Component/MergeLogic.cs
@@ -24,8 +24,8 @@ public class MergeLogic : ISimComponent
     private Port   _outPort;
     private Port[] _ports = [];
     private PortId _activePort;
-    private int    _stallTicks;
-    private const int StallThreshold = 30;
+    private float  _stallTime;
+    private const float StallSeconds = 1f;
 
     private static readonly PortId _port0 = new(0);
     private static readonly PortId _port1 = new(1);
@@ -103,11 +103,11 @@ public class MergeLogic : ISimComponent
     {
         if (Occupant == null)
         {
-            _stallTicks++;
-            if (_stallTicks >= StallThreshold)
+            _stallTime += deltaTime;
+            if (_stallTime >= StallSeconds)
             {
                 _activePort = _activePort == _port0 ? _port1 : _port0;
-                _stallTicks = 0;
+                _stallTime  = 0f;
             }
             return;
         }
@@ -137,7 +137,7 @@ public class MergeLogic : ISimComponent
         entity.CurrentComponent = this;
         entity.CurrentPort      = fromPort;
         entity.Progress         = 0.0f;
-        _stallTicks             = 0;
+        _stallTime              = 0f;
 
         if (Mode == MergeMode.Alternating)
             _activePort = _activePort == _port0 ? _port1 : _port0;

--- a/Sources/Stockflow.Simulation/Component/MergeLogic.cs
+++ b/Sources/Stockflow.Simulation/Component/MergeLogic.cs
@@ -50,7 +50,7 @@ public class MergeLogic : ISimComponent
         SetFacing(facing);
     }
 
-    public void SetFacing(Direction facing)
+    public bool SetFacing(Direction facing)
     {
         var lateralDir = Side == TurnSide.Left ? facing.RotateCCW() : facing.RotateCW();
         Facing   = facing;
@@ -58,6 +58,7 @@ public class MergeLogic : ISimComponent
         _inPort1 = new(_port1, Position + lateralDir.ToOffset(),        PortDirection.In);
         _outPort = new(_port2, Position + facing.ToOffset(),            PortDirection.Out);
         _ports   = [_inPort0, _inPort1, _outPort];
+        return true;
     }
 
     // --- ConfigSchema ---

--- a/Sources/Stockflow.Simulation/Component/OneWayConveyor.cs
+++ b/Sources/Stockflow.Simulation/Component/OneWayConveyor.cs
@@ -10,13 +10,13 @@ public class OneWayConveyor : ISimComponent
 {
     public  int                             Id       { get; }
     public  GridCoord                       Position { get; }
-    public  Direction                       Facing   { get; }
+    public  Direction                       Facing   { get; private set; }
     public  ComponentType                   Type     => ComponentType.OneWayConveyor;
     public  IReadOnlyList<IComponentModule> Modules  { get; }
     public  SimEntity?                      Occupant { get; private set; }
-    private Port                            InPort   { get; }
-    private Port                            OutPort  { get; }
-    public  IReadOnlyList<Port>             Ports    { get; }
+    private Port                            InPort   { get; set; }
+    private Port                            OutPort  { get; set; }
+    public  IReadOnlyList<Port>             Ports    { get; private set; }
     public  float                           Speed    { get; set; }
     public  RoutingGraph                    Graph    { get; }
 
@@ -32,9 +32,24 @@ public class OneWayConveyor : ISimComponent
         Modules  = modules ?? [];
         Speed    = speed;
         Graph    = graph;
-        InPort   = new(new(0), Position+Facing.Opposite().ToOffset(), PortDirection.In);
-        OutPort  = new(new(1), Position+Facing.ToOffset(), PortDirection.Out);
-        Ports    = [InPort, OutPort];
+        InPort   = default;
+        OutPort  = default;
+        Ports    = [];
+        RebuildPorts();
+    }
+
+    private void RebuildPorts()
+    {
+        InPort  = new(new(0), Position + Facing.Opposite().ToOffset(), PortDirection.In);
+        OutPort = new(new(1), Position + Facing.ToOffset(),            PortDirection.Out);
+        Ports   = [InPort, OutPort];
+    }
+
+    public bool SetFacing(Direction newFacing)
+    {
+        Facing = newFacing;
+        RebuildPorts();
+        return true;
     }
 
     // --- ConfigSchema ---

--- a/Sources/Stockflow.Simulation/Component/OneWayConveyor.cs
+++ b/Sources/Stockflow.Simulation/Component/OneWayConveyor.cs
@@ -1,3 +1,4 @@
+using Stockflow.Simulation.Core;
 using Stockflow.Simulation.Entity;
 using Stockflow.Simulation.Grid;
 using Stockflow.Simulation.Modules;
@@ -18,6 +19,9 @@ public class OneWayConveyor : ISimComponent
     public  IReadOnlyList<Port>             Ports    { get; }
     public  float                           Speed    { get; set; }
     public  RoutingGraph                    Graph    { get; }
+
+    private readonly List<SimulationEvent>  _pendingEvents = new();
+    public  IReadOnlyList<SimulationEvent>  PendingEvents  => _pendingEvents;
 
     public OneWayConveyor(int          id,    GridCoord position, Direction facing, float speed,
                           RoutingGraph graph, IReadOnlyList<IComponentModule>? modules = null)
@@ -65,6 +69,7 @@ public class OneWayConveyor : ISimComponent
 
     public void Tick(float deltaTime)
     {
+        _pendingEvents.Clear();
         if (Occupant == null) return;
         if (Occupant.Progress < 1.0f)
         {
@@ -78,10 +83,34 @@ public class OneWayConveyor : ISimComponent
                 var nextComp = next.Value.To;
                 if (nextComp.TryAccept(Occupant, next.Value.ToPort))
                 {
+                    _pendingEvents.Add(new SimulationEvent
+                    {
+                        Type        = SimulationEventType.EntityTransferred,
+                        EntityId    = Occupant.Id,
+                        ComponentId = Id,
+                    });
                     foreach (var module in Modules)
                         module.OnEntityExit(Occupant);
                     Occupant = null;
                 }
+                else
+                {
+                    _pendingEvents.Add(new SimulationEvent
+                    {
+                        Type        = SimulationEventType.ConveyorJammed,
+                        EntityId    = Occupant.Id,
+                        ComponentId = Id,
+                    });
+                }
+            }
+            else
+            {
+                _pendingEvents.Add(new SimulationEvent
+                {
+                    Type        = SimulationEventType.ConveyorJammed,
+                    EntityId    = Occupant.Id,
+                    ComponentId = Id,
+                });
             }
         }
     }

--- a/Sources/Stockflow.Simulation/Component/OneWayConveyor.cs
+++ b/Sources/Stockflow.Simulation/Component/OneWayConveyor.cs
@@ -68,7 +68,7 @@ public class OneWayConveyor : ISimComponent
         if (Occupant == null) return;
         if (Occupant.Progress < 1.0f)
         {
-            Occupant.Progress += Speed * deltaTime;
+            Occupant.Progress = MathF.Min(Occupant.Progress + Speed * deltaTime, 1.0f);
         }
         else
         {

--- a/Sources/Stockflow.Simulation/Component/PackageExit.cs
+++ b/Sources/Stockflow.Simulation/Component/PackageExit.cs
@@ -1,4 +1,5 @@
 using System;
+using Stockflow.Simulation.Core;
 using Stockflow.Simulation.Entity;
 using Stockflow.Simulation.Grid;
 using Stockflow.Simulation.Modules;
@@ -14,20 +15,22 @@ public class PackageExit : ISimComponent
 {
     private const float ThroughputWindow = 10f; // rolling window in seconds
 
-    private readonly EntityManager _entities;
-    private readonly Port          _inPort;
-    private readonly Func<float>?  _getSimTime;
-    private readonly Queue<float>  _recentCompletionTimes = new();
-    private          float         _simTime;
-    private          float         _totalFulfillmentTime;
+    private readonly EntityManager        _entities;
+    private readonly Port                 _inPort;
+    private readonly Func<float>?         _getSimTime;
+    private readonly Queue<float>         _recentCompletionTimes = new();
+    private readonly List<SimulationEvent> _pendingEvents = new();
+    private          float                _simTime;
+    private          float                _totalFulfillmentTime;
 
-    public int                             Id       { get; }
-    public GridCoord                       Position { get; }
-    public Direction                       Facing   { get; }
-    public ComponentType                   Type     => ComponentType.PackageExit;
-    public IReadOnlyList<IComponentModule> Modules  { get; }
-    public SimEntity?                      Occupant { get; private set; }
-    public IReadOnlyList<Port>             Ports    { get; }
+    public int                             Id            { get; }
+    public GridCoord                       Position      { get; }
+    public Direction                       Facing        { get; }
+    public ComponentType                   Type          => ComponentType.PackageExit;
+    public IReadOnlyList<IComponentModule> Modules       { get; }
+    public SimEntity?                      Occupant      { get; private set; }
+    public IReadOnlyList<Port>             Ports         { get; }
+    public IReadOnlyList<SimulationEvent>  PendingEvents => _pendingEvents;
 
     private float CurrentSimTime => _getSimTime?.Invoke() ?? _simTime;
 
@@ -81,6 +84,7 @@ public class PackageExit : ISimComponent
 
     public void Tick(float deltaTime)
     {
+        _pendingEvents.Clear();
         _simTime += deltaTime;
 
         if (Occupant == null) return;
@@ -94,6 +98,13 @@ public class PackageExit : ISimComponent
         // Trim completions that have left the rolling window
         while (_recentCompletionTimes.Count > 0 && now - _recentCompletionTimes.Peek() > ThroughputWindow)
             _recentCompletionTimes.Dequeue();
+
+        _pendingEvents.Add(new SimulationEvent
+        {
+            Type        = SimulationEventType.EntityTransferred,
+            EntityId    = Occupant.Id,
+            ComponentId = Id,
+        });
 
         foreach (var m in Modules)
             m.OnEntityExit(Occupant);

--- a/Sources/Stockflow.Simulation/Component/PackageExit.cs
+++ b/Sources/Stockflow.Simulation/Component/PackageExit.cs
@@ -113,6 +113,8 @@ public class PackageExit : ISimComponent
         Occupant = null;
     }
 
+    public bool SetFacing(Direction newFacing) => false;
+
     public bool TryAccept(SimEntity entity, PortId fromPort)
     {
         if (Occupant != null) return false;

--- a/Sources/Stockflow.Simulation/Component/PackageExit.cs
+++ b/Sources/Stockflow.Simulation/Component/PackageExit.cs
@@ -1,3 +1,4 @@
+using System;
 using Stockflow.Simulation.Entity;
 using Stockflow.Simulation.Grid;
 using Stockflow.Simulation.Modules;
@@ -15,6 +16,7 @@ public class PackageExit : ISimComponent
 
     private readonly EntityManager _entities;
     private readonly Port          _inPort;
+    private readonly Func<float>?  _getSimTime;
     private readonly Queue<float>  _recentCompletionTimes = new();
     private          float         _simTime;
     private          float         _totalFulfillmentTime;
@@ -27,10 +29,12 @@ public class PackageExit : ISimComponent
     public SimEntity?                      Occupant { get; private set; }
     public IReadOnlyList<Port>             Ports    { get; }
 
+    private float CurrentSimTime => _getSimTime?.Invoke() ?? _simTime;
+
     // Read-only metrics visible to the frontend
     public int   TotalProcessed     { get; private set; }
     public float Throughput         => _recentCompletionTimes.Count > 0
-                                           ? _recentCompletionTimes.Count / MathF.Min(_simTime, ThroughputWindow)
+                                           ? _recentCompletionTimes.Count / MathF.Min(CurrentSimTime, ThroughputWindow)
                                            : 0f;
     public float AvgFulfillmentTime => TotalProcessed > 0
                                            ? _totalFulfillmentTime / TotalProcessed
@@ -38,15 +42,17 @@ public class PackageExit : ISimComponent
 
     public PackageExit(int id, GridCoord position, Direction facing,
                        EntityManager entities,
+                       Func<float>? getSimTime = null,
                        IReadOnlyList<IComponentModule>? modules = null)
     {
-        Id        = id;
-        Position  = position;
-        Facing    = facing;
-        _entities = entities;
-        Modules   = modules ?? [];
-        _inPort   = new(new(0), Position + Facing.Opposite().ToOffset(), PortDirection.In);
-        Ports     = [_inPort];
+        Id          = id;
+        Position    = position;
+        Facing      = facing;
+        _entities   = entities;
+        _getSimTime = getSimTime;
+        Modules     = modules ?? [];
+        _inPort     = new(new(0), Position + Facing.Opposite().ToOffset(), PortDirection.In);
+        Ports       = [_inPort];
     }
 
     // --- ConfigSchema ---
@@ -79,13 +85,14 @@ public class PackageExit : ISimComponent
 
         if (Occupant == null) return;
 
-        var fulfillment = _simTime - Occupant.EntryTime;
+        var now         = CurrentSimTime;
+        var fulfillment = now - Occupant.EntryTime;
         TotalProcessed++;
         _totalFulfillmentTime += fulfillment;
-        _recentCompletionTimes.Enqueue(_simTime);
+        _recentCompletionTimes.Enqueue(now);
 
         // Trim completions that have left the rolling window
-        while (_recentCompletionTimes.Count > 0 && _simTime - _recentCompletionTimes.Peek() > ThroughputWindow)
+        while (_recentCompletionTimes.Count > 0 && now - _recentCompletionTimes.Peek() > ThroughputWindow)
             _recentCompletionTimes.Dequeue();
 
         foreach (var m in Modules)

--- a/Sources/Stockflow.Simulation/Component/PackageExit.cs
+++ b/Sources/Stockflow.Simulation/Component/PackageExit.cs
@@ -102,6 +102,8 @@ public class PackageExit : ISimComponent
         entity.CurrentComponent = this;
         entity.CurrentPort      = fromPort;
         entity.Progress         = 0f;
+        foreach (var m in Modules)
+            m.OnEntityEnter(entity);
         return true;
     }
 }

--- a/Sources/Stockflow.Simulation/Component/PackageGenerator.cs
+++ b/Sources/Stockflow.Simulation/Component/PackageGenerator.cs
@@ -1,3 +1,4 @@
+using System;
 using Stockflow.Simulation.Entity;
 using Stockflow.Simulation.Grid;
 using Stockflow.Simulation.Modules;
@@ -13,6 +14,7 @@ public class PackageGenerator : ISimComponent
 {
     private readonly EntityManager _entities;
     private readonly Port          _outPort;
+    private readonly Func<float>?  _getSimTime;
     private          float         _accumulated;
     private          float         _simTime;
 
@@ -36,20 +38,22 @@ public class PackageGenerator : ISimComponent
                             float spawnRate, string sku, float weight, float size,
                             RoutingGraph graph,
                             EntityManager entities,
+                            Func<float>? getSimTime = null,
                             IReadOnlyList<IComponentModule>? modules = null)
     {
-        Id        = id;
-        Position  = position;
-        Facing    = facing;
-        SpawnRate = spawnRate;
-        Sku       = sku;
-        Weight    = weight;
-        Size      = size;
-        Graph     = graph;
-        _entities = entities;
-        Modules   = modules ?? [];
-        _outPort  = new(new(0), Position + Facing.ToOffset(), PortDirection.Out);
-        Ports     = [_outPort];
+        Id          = id;
+        Position    = position;
+        Facing      = facing;
+        SpawnRate   = spawnRate;
+        Sku         = sku;
+        Weight      = weight;
+        Size        = size;
+        Graph       = graph;
+        _entities   = entities;
+        _getSimTime = getSimTime;
+        Modules     = modules ?? [];
+        _outPort    = new(new(0), Position + Facing.ToOffset(), PortDirection.Out);
+        Ports       = [_outPort];
     }
 
     // --- ConfigSchema ---
@@ -128,7 +132,8 @@ public class PackageGenerator : ISimComponent
         if (_accumulated < 1f / SpawnRate) return;
 
         _accumulated -= 1f / SpawnRate;
-        Occupant = _entities.Spawn(Sku, Weight, Size, _simTime, this, _outPort.Id);
+        var currentTime = _getSimTime?.Invoke() ?? _simTime;
+        Occupant = _entities.Spawn(Sku, Weight, Size, currentTime, this, _outPort.Id);
     }
 
     // Generators are source-only — nothing enters them

--- a/Sources/Stockflow.Simulation/Component/PackageGenerator.cs
+++ b/Sources/Stockflow.Simulation/Component/PackageGenerator.cs
@@ -108,8 +108,6 @@ public class PackageGenerator : ISimComponent
 
     public void Tick(float deltaTime)
     {
-        _simTime += deltaTime;
-
         // Try to push buffered entity downstream first (natural backpressure)
         if (Occupant != null)
         {
@@ -125,6 +123,7 @@ public class PackageGenerator : ISimComponent
 
         if (!IsEnabled || SpawnRate <= 0f) return;
 
+        _simTime     += deltaTime;
         _accumulated += deltaTime;
         if (_accumulated < 1f / SpawnRate) return;
 

--- a/Sources/Stockflow.Simulation/Component/PackageGenerator.cs
+++ b/Sources/Stockflow.Simulation/Component/PackageGenerator.cs
@@ -138,6 +138,8 @@ public class PackageGenerator : ISimComponent
         Occupant = _entities.Spawn(Sku, Weight, Size, currentTime, this, _outPort.Id);
     }
 
+    public bool SetFacing(Direction newFacing) => false;
+
     // Generators are source-only — nothing enters them
     public bool TryAccept(SimEntity entity, PortId fromPort) => false;
 }

--- a/Sources/Stockflow.Simulation/Component/PackageGenerator.cs
+++ b/Sources/Stockflow.Simulation/Component/PackageGenerator.cs
@@ -26,7 +26,8 @@ public class PackageGenerator : ISimComponent
     public IReadOnlyList<IComponentModule> Modules       { get; }
     public SimEntity?                      Occupant      { get; private set; }
     public IReadOnlyList<Port>             Ports         { get; }
-    public IReadOnlyList<SimulationEvent>  PendingEvents => [];
+    private static readonly IReadOnlyList<SimulationEvent> _noPendingEvents = [];
+    public IReadOnlyList<SimulationEvent>  PendingEvents => _noPendingEvents;
     public RoutingGraph                    Graph         { get; }
 
     // Configurable parameters

--- a/Sources/Stockflow.Simulation/Component/PackageGenerator.cs
+++ b/Sources/Stockflow.Simulation/Component/PackageGenerator.cs
@@ -1,4 +1,5 @@
 using System;
+using Stockflow.Simulation.Core;
 using Stockflow.Simulation.Entity;
 using Stockflow.Simulation.Grid;
 using Stockflow.Simulation.Modules;
@@ -18,14 +19,15 @@ public class PackageGenerator : ISimComponent
     private          float         _accumulated;
     private          float         _simTime;
 
-    public int                             Id       { get; }
-    public GridCoord                       Position { get; }
-    public Direction                       Facing   { get; }
-    public ComponentType                   Type     => ComponentType.PackageGenerator;
-    public IReadOnlyList<IComponentModule> Modules  { get; }
-    public SimEntity?                      Occupant { get; private set; }
-    public IReadOnlyList<Port>             Ports    { get; }
-    public RoutingGraph                    Graph    { get; }
+    public int                             Id            { get; }
+    public GridCoord                       Position      { get; }
+    public Direction                       Facing        { get; }
+    public ComponentType                   Type          => ComponentType.PackageGenerator;
+    public IReadOnlyList<IComponentModule> Modules       { get; }
+    public SimEntity?                      Occupant      { get; private set; }
+    public IReadOnlyList<Port>             Ports         { get; }
+    public IReadOnlyList<SimulationEvent>  PendingEvents => [];
+    public RoutingGraph                    Graph         { get; }
 
     // Configurable parameters
     public float  SpawnRate { get; set; }   // entities per second

--- a/Sources/Stockflow.Simulation/Core/SimulationClock.cs
+++ b/Sources/Stockflow.Simulation/Core/SimulationClock.cs
@@ -5,22 +5,23 @@ public class SimulationClock
     private float _simulatedTime;
 
     public float SimulatedTime => _simulatedTime;
-
     public float TimeScale { get; set; } = 1f;
 
-    // Phase 2: enforced at 1x when external connections are active
-    public bool IsLiveMode => TimeScale == 1f;
+    // Phase 2: enforced at 1x when external connections are active.
+    // Must be set explicitly via EnterLiveMode() / ExitLiveMode().
+    public bool IsLiveMode { get; private set; }
+
+    public void EnterLiveMode() => IsLiveMode = true;
+    public void ExitLiveMode()  => IsLiveMode = false;
 
     // Caller already supplies a pre-scaled delta (1f/tickRate * TimeScale).
-    public void Advance(float delta)
-    {
-        _simulatedTime += delta;
-    }
+    public void Advance(float delta) => _simulatedTime += delta;
 
     // Azzera il tempo simulato preservando TimeScale (la velocità di playback
     // appartiene alla preferenza utente, non allo scenario).
     public void Reset()
     {
         _simulatedTime = 0f;
+        IsLiveMode     = false;
     }
 }

--- a/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
+++ b/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
@@ -15,10 +15,10 @@ public class SimulationEngine
     private int                          _nextComponentId   = 1;
     private readonly List<SimulationEvent> _pendingEvents   = new();
 
-    public SimulationEngine(int width, int length, int height)
+    public SimulationEngine(int width, int length, int floors)
     {
         Clock = new SimulationClock();
-        Grid  = new GridManager(width, length, height);
+        Grid  = new GridManager(width, length, floors);
         Graph = new RoutingGraph();
         State = new();
 

--- a/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
+++ b/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
@@ -142,19 +142,17 @@ public class SimulationEngine
             return CommandResult.Fail($"Component {cmd.ComponentId} not found");
 
         // --- Special case: facing change requires RoutingGraph surgery ---
-        if (cmd.Properties.TryGetValue("facing", out var facingStr) &&
-            Enum.TryParse<Direction>(facingStr, ignoreCase: true, out var newDir) &&
-            newDir != component.Facing)
+        if (cmd.Properties.TryGetValue("facing", out var facingStr))
         {
-            switch (component)
+            if (!Enum.TryParse<Direction>(facingStr, ignoreCase: true, out var newDir))
+                return CommandResult.Fail($"Invalid direction: {facingStr}");
+
+            if (newDir != component.Facing)
             {
-                case MergeLogic merge:
-                    Graph.DisconnectAll(merge);
-                    merge.SetFacing(newDir);
-                    AutoConnect(merge);
-                    break;
-                default:
-                    return CommandResult.Fail($"Component type {component.Type} does not support runtime facing change");
+                Graph.DisconnectAll(component);
+                if (!component.SetFacing(newDir))
+                    return CommandResult.Fail($"Component type {component.Type} does not support runtime facing changes");
+                AutoConnect(component);
             }
         }
 

--- a/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
+++ b/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
@@ -70,7 +70,11 @@ public class SimulationEngine
     {
         Clock.Advance(deltaTime);
         foreach (var component in State.Components)
+        {
             component.Tick(deltaTime);
+            foreach (var module in component.Modules)
+                module.OnTick(deltaTime);
+        }
     }
 
     public CommandResult ProcessCommand(ICommand command)

--- a/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
+++ b/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
@@ -38,12 +38,14 @@ public class SimulationEngine
                 var x = (PlacePackageGeneratorCommand)c;
                 return new PackageGenerator(id, x.Position, x.Facing,
                                             x.SpawnRate, x.Sku, x.Weight, x.Size,
-                                            Graph, State.Entities);
+                                            Graph, State.Entities,
+                                            getSimTime: () => Clock.SimulatedTime);
             },
             [typeof(PlacePackageExitCommand)] = (c, id) =>
             {
                 var x = (PlacePackageExitCommand)c;
-                return new PackageExit(id, x.Position, x.Facing, State.Entities);
+                return new PackageExit(id, x.Position, x.Facing, State.Entities,
+                                       getSimTime: () => Clock.SimulatedTime);
             },
             [typeof(PlaceMergeLogicCommand)] = (c, id) =>
             {

--- a/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
+++ b/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
@@ -13,6 +13,7 @@ public class SimulationEngine
     private HashSet<int>                 _knownEntityIds    = new();
     private Dictionary<int, EntityState> _lastEntityStates  = new();
     private int                          _nextComponentId   = 1;
+    private readonly List<SimulationEvent> _pendingEvents   = new();
 
     public SimulationEngine(int width, int length, int height)
     {
@@ -74,6 +75,7 @@ public class SimulationEngine
         foreach (var component in State.Components)
         {
             component.Tick(deltaTime);
+            _pendingEvents.AddRange(component.PendingEvents);
             foreach (var module in component.Modules)
                 module.OnTick(deltaTime);
         }
@@ -245,6 +247,9 @@ public class SimulationEngine
             return true;
         });
 
+        var events = _pendingEvents.ToList();
+        _pendingEvents.Clear();
+
         return new StateDelta
         {
             SimulationTime      = Clock.SimulatedTime,
@@ -253,6 +258,7 @@ public class SimulationEngine
             AddedEntityStates   = addedEntities,
             UpdatedEntityStates = updatedEntities,
             RemovedEntityIds    = removedEntities,
+            Events              = events,
         };
     }
 }

--- a/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
+++ b/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
@@ -151,7 +151,11 @@ public class SimulationEngine
             {
                 Graph.DisconnectAll(component);
                 if (!component.SetFacing(newDir))
+                {
+                    // SetFacing failed — reconnect to avoid leaving the component orphaned
+                    AutoConnect(component);
                     return CommandResult.Fail($"Component type {component.Type} does not support runtime facing changes");
+                }
                 AutoConnect(component);
             }
         }

--- a/Sources/Stockflow.Simulation/Entity/Entity.cs
+++ b/Sources/Stockflow.Simulation/Entity/Entity.cs
@@ -10,7 +10,7 @@ public class SimEntity
     public float   Size      { get; internal set; }
     public float   EntryTime { get; internal set; }
 
-    public ISimComponent  CurrentComponent     { get; set; } = null!;
+    public ISimComponent? CurrentComponent     { get; set; }
     public PortId         CurrentPort          { get; set; }
     public float          Progress             { get; set; }   // 0.0 ingresso → 1.0 uscita
 
@@ -23,7 +23,7 @@ public class SimEntity
     internal void Reset()
     {
         Sku                  = "";
-        CurrentComponent     = null!;
+        CurrentComponent     = null;
         DestinationComponent = null;
     }
 }

--- a/Sources/Stockflow.Simulation/Entity/EntityManager.cs
+++ b/Sources/Stockflow.Simulation/Entity/EntityManager.cs
@@ -13,7 +13,7 @@ public class EntityManager
     public IReadOnlyCollection<SimEntity> GetAll() => _active.Values;
 
     public IEnumerable<SimEntity> GetByComponent(int componentId)
-        => _active.Values.Where(e => e.CurrentComponent.Id == componentId);
+        => _active.Values.Where(e => e.CurrentComponent?.Id == componentId);
 
     public SimEntity Spawn(string sku, float weight, float size, float entryTime,
                            ISimComponent startComponent, PortId startPort)

--- a/Sources/Stockflow.Simulation/Entity/EntityState.cs
+++ b/Sources/Stockflow.Simulation/Entity/EntityState.cs
@@ -17,7 +17,7 @@ public sealed record EntityState
     {
         Id                 = e.Id,
         Sku                = e.Sku,
-        CurrentComponentId = e.CurrentComponent.Id,
+        CurrentComponentId = e.CurrentComponent?.Id ?? 0,
         CurrentPort        = e.CurrentPort,
         Progress           = e.Progress,
         Status             = e.Status,

--- a/Sources/Stockflow.Simulation/Grid/Cell.cs
+++ b/Sources/Stockflow.Simulation/Grid/Cell.cs
@@ -17,13 +17,13 @@ public class GridManager
 
     public int Width  { get; }
     public int Length { get; }
-    public int Height { get; }
+    public int Floors { get; }
 
-    public GridManager(int width, int length, int height)
+    public GridManager(int width, int length, int floors)
     {
         Width  = width;
         Length = length;
-        Height = height;
+        Floors = floors;
 
         _grid = new Cell[width][][];
         for (int x = 0; x < width; x++)
@@ -31,8 +31,8 @@ public class GridManager
             _grid[x] = new Cell[length][];
             for (int y = 0; y < length; y++)
             {
-                _grid[x][y] = new Cell[height];
-                for (int z = 0; z < height; z++)
+                _grid[x][y] = new Cell[floors];
+                for (int z = 0; z < floors; z++)
                     _grid[x][y][z] = new Cell(new GridCoord(x, y, z));
             }
         }
@@ -41,7 +41,7 @@ public class GridManager
     public bool IsInBounds(GridCoord coord) =>
         coord.X >= 0 && coord.X < Width  &&
         coord.Y >= 0 && coord.Y < Length &&
-        coord.Floor >= 0 && coord.Floor < Height;
+        coord.Floor >= 0 && coord.Floor < Floors;
 
     public bool TryGetCell(GridCoord coord, out Cell cell)
     {

--- a/Sources/Stockflow.Simulation/Routing/RoutingGraph.cs
+++ b/Sources/Stockflow.Simulation/Routing/RoutingGraph.cs
@@ -9,7 +9,13 @@ public class RoutingGraph
     public void Connect(ISimComponent from, PortId fromPort,
                         ISimComponent to,   PortId toPort)
     {
-        connections[(from, fromPort)] = new Connection(from, fromPort, to, toPort);
+        var key = (from, fromPort);
+        if (connections.ContainsKey(key))
+            throw new InvalidOperationException(
+                $"Output port {fromPort} of component {from.Id} is already connected. " +
+                $"Call Disconnect first.");
+
+        connections[key] = new Connection(from, fromPort, to, toPort);
     }
 
     public void Disconnect(ISimComponent component, PortId port)

--- a/Sources/Stockflow.Tests.Simulation/Helpers/StubComponent.cs
+++ b/Sources/Stockflow.Tests.Simulation/Helpers/StubComponent.cs
@@ -21,6 +21,7 @@ internal sealed class StubComponent(int id = 0, GridCoord position = default) : 
     public IReadOnlyList<PropertySchema>          ConfigSchema      => [];
     public string?                                ApplyConfig(IReadOnlyDictionary<string, string> properties) => null;
     public Dictionary<string, string>             ExportProperties() => [];
+    public bool                                   SetFacing(Direction newFacing) => false;
 
     public void Tick(float deltaTime) => TickCount++;
 

--- a/Sources/Stockflow.Tests.Simulation/Helpers/StubComponent.cs
+++ b/Sources/Stockflow.Tests.Simulation/Helpers/StubComponent.cs
@@ -1,4 +1,5 @@
 using Stockflow.Simulation.Component;
+using Stockflow.Simulation.Core;
 using Stockflow.Simulation.Entity;
 using Stockflow.Simulation.Grid;
 using Stockflow.Simulation.Modules;
@@ -16,6 +17,7 @@ internal sealed class StubComponent(int id = 0, GridCoord position = default) : 
     public IReadOnlyList<Port>             Ports    => [];
     public int                             TickCount { get; private set; }
 
+    public IReadOnlyList<SimulationEvent>          PendingEvents     => [];
     public IReadOnlyList<PropertySchema>          ConfigSchema      => [];
     public string?                                ApplyConfig(IReadOnlyDictionary<string, string> properties) => null;
     public Dictionary<string, string>             ExportProperties() => [];

--- a/Sources/Stockflow.Tests.Simulation/LoadScenarioCommandTests.cs
+++ b/Sources/Stockflow.Tests.Simulation/LoadScenarioCommandTests.cs
@@ -23,7 +23,7 @@ public class LoadScenarioCommandTests
         Assert.True(result.Success);
         Assert.Equal(20, engine.Grid.Width);
         Assert.Equal(15, engine.Grid.Length);
-        Assert.Equal(2,  engine.Grid.Height);
+        Assert.Equal(2,  engine.Grid.Floors);
     }
 
     [Fact]

--- a/Sources/Stockflow.Tests.Simulation/MergeLogicTests.cs
+++ b/Sources/Stockflow.Tests.Simulation/MergeLogicTests.cs
@@ -114,7 +114,8 @@ public class MergeLogicTests
         var merge = MakeMerge(MergeMode.Priority);
         var mgr   = new EntityManager();
 
-        for (int i = 0; i < 30; i++) merge.Tick(0f);
+        // Stall for > 1 second (threshold) at 10 Hz
+        for (int i = 0; i < 11; i++) merge.Tick(0.1f);
 
         var entity = mgr.Spawn("A", 1f, 1f, 0f, merge, new PortId(1));
         Assert.True(merge.TryAccept(entity, new PortId(1)));
@@ -129,7 +130,8 @@ public class MergeLogicTests
         var exit  = new PackageExit(2, new GridCoord(0, -1), Direction.North, mgr);
         graph.Connect(merge, new PortId(2), exit, new PortId(0));
 
-        for (int i = 0; i < 30; i++) merge.Tick(0f);
+        // Stall for > 1 second (threshold) at 10 Hz
+        for (int i = 0; i < 11; i++) merge.Tick(0.1f);
 
         var e1 = mgr.Spawn("A", 1f, 1f, 0f, merge, new PortId(1));
         merge.TryAccept(e1, new PortId(1));
@@ -183,7 +185,7 @@ public class MergeLogicTests
     }
 
     [Fact]
-    public void StallTicks_ResetOnAccept()
+    public void StallTime_ResetOnAccept()
     {
         var graph = new RoutingGraph();
         var merge = MakeMerge(MergeMode.Priority, graph);
@@ -191,13 +193,15 @@ public class MergeLogicTests
         var exit  = new PackageExit(2, new GridCoord(0, -1), Direction.North, mgr);
         graph.Connect(merge, new PortId(2), exit, new PortId(0));
 
-        for (int i = 0; i < 15; i++) merge.Tick(0f);
+        // Stall for 0.5s (below 1s threshold) at 10 Hz
+        for (int i = 0; i < 5; i++) merge.Tick(0.1f);
 
         var e1 = mgr.Spawn("A", 1f, 1f, 0f, merge, new PortId(0));
         merge.TryAccept(e1, new PortId(0));
         merge.Tick(1f); merge.Tick(0f); exit.Tick(0f);
 
-        for (int i = 0; i < 29; i++) merge.Tick(0f);
+        // Stall for 0.9s after accept (below threshold — should not switch)
+        for (int i = 0; i < 9; i++) merge.Tick(0.1f);
 
         var e2 = mgr.Spawn("B", 1f, 1f, 0f, merge, new PortId(1));
         Assert.False(merge.TryAccept(e2, new PortId(1)));
@@ -253,5 +257,40 @@ public class MergeLogicTests
         Assert.Equal(new GridCoord(-1, 0), merge.Ports[0].Position);
         Assert.Equal(new GridCoord(0,  1), merge.Ports[1].Position);
         Assert.Equal(new GridCoord(1,  0), merge.Ports[2].Position);
+    }
+
+    [Theory]
+    [InlineData(10f,  0.1f)]   // 10 Hz tick rate
+    [InlineData(100f, 0.01f)]  // 100 Hz tick rate
+    public void Alternating_StarvationSwitchesAtSameWallTime_RegardlessOfTickRate(
+        float ticksPerSecond, float deltaTime)
+    {
+        var graph = new RoutingGraph();
+        var merge = new MergeLogic(1, new GridCoord(0, 0), Direction.North,
+                                   MergeMode.Alternating, TurnSide.Left, 1f, graph);
+        var mgr   = new EntityManager();
+
+        // Merge is empty; stall threshold = 1 second.
+        // Tick for just under 1 second → port0 should still be active.
+        var ticksBelowThreshold = (int)(0.9f / deltaTime);
+        for (var i = 0; i < ticksBelowThreshold; i++)
+            merge.Tick(deltaTime);
+
+        var entity0 = mgr.Spawn("A", 1f, 1f, 0f, merge, new PortId(0));
+        Assert.True(merge.TryAccept(entity0, new PortId(0)),
+            "Port0 should still be active before stall threshold");
+
+        // Reset: create a fresh merge to test the "above threshold" side independently
+        var merge2 = new MergeLogic(2, new GridCoord(0, 0), Direction.North,
+                                    MergeMode.Alternating, TurnSide.Left, 1f, graph);
+
+        // Tick for over 1 second → should switch to port1
+        var ticksAboveThreshold = (int)(1.1f / deltaTime);
+        for (var i = 0; i < ticksAboveThreshold; i++)
+            merge2.Tick(deltaTime);
+
+        var entity1 = mgr.Spawn("B", 1f, 1f, 0f, merge2, new PortId(1));
+        Assert.True(merge2.TryAccept(entity1, new PortId(1)),
+            $"Port1 should be active after stall threshold at {ticksPerSecond}Hz");
     }
 }

--- a/Sources/Stockflow.Tests.Simulation/OneWayConveyorTests.cs
+++ b/Sources/Stockflow.Tests.Simulation/OneWayConveyorTests.cs
@@ -81,4 +81,21 @@ public class OneWayConveyorTests
 
         Assert.Same(entity, conveyor.Occupant);
     }
+
+    [Fact]
+    public void Tick_WhenBlocked_ProgressClampedAtOne()
+    {
+        var graph  = new RoutingGraph();
+        var conv   = new OneWayConveyor(1, new GridCoord(0, 0), Direction.North, 5f, graph);
+        var mgr    = new EntityManager();
+        var entity = mgr.Spawn("X", 1f, 1f, 0f, conv, new PortId(0));
+        conv.TryAccept(entity, new PortId(0));
+
+        // Tick many times with no next component → blocked
+        conv.Tick(1f);
+        conv.Tick(1f);
+        conv.Tick(1f);
+
+        Assert.Equal(1f, entity.Progress);
+    }
 }

--- a/Sources/Stockflow.Tests.Simulation/PackageExitTests.cs
+++ b/Sources/Stockflow.Tests.Simulation/PackageExitTests.cs
@@ -2,6 +2,7 @@ using Stockflow.Simulation.Component;
 using Stockflow.Simulation.Entity;
 using Stockflow.Simulation.Grid;
 using Stockflow.Simulation.Modules;
+using Stockflow.Simulation.Routing;
 
 namespace Stockflow.Tests.Simulation;
 
@@ -162,5 +163,32 @@ public class PackageExitTests
         exit.TryAccept(entity, new PortId(0));
 
         Assert.Equal(1, spy.EnterCount);
+    }
+
+    [Fact]
+    public void FulfillmentTime_IsPositive_WhenExitCreatedAfterGeneratorHasRun()
+    {
+        var sharedTime = 0f;
+        var mgr        = new EntityManager();
+        var graph      = new RoutingGraph();
+
+        var gen = new PackageGenerator(1, new GridCoord(0, 0), Direction.North,
+                                       1f, "PKG", 1f, 1f, graph, mgr,
+                                       getSimTime: () => sharedTime);
+        sharedTime = 5f;
+        gen.Tick(1f); // spawns entity with entryTime=5
+
+        var exit = new PackageExit(2, new GridCoord(0, 1), Direction.North, mgr,
+                                   getSimTime: () => sharedTime);
+        graph.Connect(gen, gen.Ports[0].Id, exit, exit.Ports[0].Id);
+
+        sharedTime = 5.5f;
+        gen.Tick(0f);   // push entity to exit
+
+        sharedTime = 6f;
+        exit.Tick(0.5f);
+
+        Assert.True(exit.AvgFulfillmentTime > 0f,
+            $"Fulfillment time should be positive, was {exit.AvgFulfillmentTime}");
     }
 }

--- a/Sources/Stockflow.Tests.Simulation/PackageExitTests.cs
+++ b/Sources/Stockflow.Tests.Simulation/PackageExitTests.cs
@@ -1,6 +1,7 @@
 using Stockflow.Simulation.Component;
 using Stockflow.Simulation.Entity;
 using Stockflow.Simulation.Grid;
+using Stockflow.Simulation.Modules;
 
 namespace Stockflow.Tests.Simulation;
 
@@ -137,5 +138,29 @@ public class PackageExitTests
 
         // East.Opposite() = West → InPort.Position = (2,2) + (-1,0) = (1,2)
         Assert.Equal(new GridCoord(1, 2), inPort.Position);
+    }
+
+    private sealed class SpyModule : IComponentModule
+    {
+        public int EnterCount { get; private set; }
+        public int ExitCount  { get; private set; }
+        public int TickCount  { get; private set; }
+        public void OnEntityEnter(SimEntity e) => EnterCount++;
+        public void OnEntityExit(SimEntity e)  => ExitCount++;
+        public void OnTick(float dt)           => TickCount++;
+    }
+
+    [Fact]
+    public void TryAccept_NotifiesModuleOnEntityEnter()
+    {
+        var mgr    = new EntityManager();
+        var spy    = new SpyModule();
+        var exit   = new PackageExit(1, new GridCoord(0, 0), Direction.North, mgr,
+                                     modules: [spy]);
+        var entity = mgr.Spawn("X", 1f, 1f, 0f, exit, new PortId(0));
+
+        exit.TryAccept(entity, new PortId(0));
+
+        Assert.Equal(1, spy.EnterCount);
     }
 }

--- a/Sources/Stockflow.Tests.Simulation/RoutingGraphTests.cs
+++ b/Sources/Stockflow.Tests.Simulation/RoutingGraphTests.cs
@@ -1,0 +1,40 @@
+using Stockflow.Simulation.Component;
+using Stockflow.Simulation.Grid;
+using Stockflow.Simulation.Routing;
+using Stockflow.Tests.Simulation.Helpers;
+
+namespace Stockflow.Tests.Simulation;
+
+public class RoutingGraphTests
+{
+    [Fact]
+    public void Connect_SamePortTwice_ThrowsInvalidOperation()
+    {
+        var graph = new RoutingGraph();
+        var compA = new StubComponent(1, new GridCoord(0, 0));
+        var compB = new StubComponent(2, new GridCoord(1, 0));
+        var compC = new StubComponent(3, new GridCoord(2, 0));
+        var port  = new PortId(1);
+
+        graph.Connect(compA, port, compB, new PortId(0));
+
+        Assert.Throws<InvalidOperationException>(
+            () => graph.Connect(compA, port, compC, new PortId(0)));
+    }
+
+    [Fact]
+    public void Connect_AfterDisconnect_Succeeds()
+    {
+        var graph = new RoutingGraph();
+        var compA = new StubComponent(1, new GridCoord(0, 0));
+        var compB = new StubComponent(2, new GridCoord(1, 0));
+        var compC = new StubComponent(3, new GridCoord(2, 0));
+        var port  = new PortId(1);
+
+        graph.Connect(compA, port, compB, new PortId(0));
+        graph.Disconnect(compA, port);
+        graph.Connect(compA, port, compC, new PortId(0)); // must not throw
+
+        Assert.Equal(compC, graph.GetNext(compA, port)!.Value.To);
+    }
+}

--- a/Sources/Stockflow.Tests.Simulation/SimulationEngineTests.cs
+++ b/Sources/Stockflow.Tests.Simulation/SimulationEngineTests.cs
@@ -250,4 +250,30 @@ public class SimulationEngineTests
         Assert.Contains(delta.Events,
             e => e.Type == SimulationEventType.ConveyorJammed && e.EntityId == entity.Id);
     }
+
+    [Theory]
+    [InlineData("OneWayConveyor")]
+    [InlineData("ConveyorTurn")]
+    [InlineData("Diverter")]
+    public void ConfigureComponent_SetFacing_SucceedsForConveyorTypes(string kind)
+    {
+        var engine = new SimulationEngine(10, 10, 1);
+        ICommand placeCmd = kind switch
+        {
+            "OneWayConveyor" => new PlaceOneWayConveyorCommand(new GridCoord(5, 5), Direction.North, 1f),
+            "ConveyorTurn"   => new PlaceConveyorTurnCommand(new GridCoord(5, 5), Direction.North,
+                                                              TurnSide.Right, 1f),
+            "Diverter"       => new PlaceDiverterLogicCommand(new GridCoord(5, 5), Direction.North,
+                                                               TurnSide.Right, 1f),
+            _                => throw new ArgumentException(kind),
+        };
+        engine.ProcessCommand(placeCmd);
+        var comp = engine.State.Components[0];
+
+        var result = engine.ProcessCommand(new ConfigureComponentCommand(comp.Id,
+            new Dictionary<string, string> { ["facing"] = "East" }));
+
+        Assert.True(result.Success, result.ErrorMessage ?? "no error message");
+        Assert.Equal(Direction.East, comp.Facing);
+    }
 }

--- a/Sources/Stockflow.Tests.Simulation/SimulationEngineTests.cs
+++ b/Sources/Stockflow.Tests.Simulation/SimulationEngineTests.cs
@@ -205,4 +205,49 @@ public class SimulationEngineTests
 
         Assert.Equal(2, spy.OnTickCallCount);
     }
+
+    [Fact]
+    public void GetStateDelta_AfterEntityTransfer_ContainsEntityTransferredEvent()
+    {
+        // Place two conveyors adjacent so AutoConnect wires them together.
+        // North = offset (0,-1), so c1 facing South has OutPort at (0,1).
+        // c1 at (0,0) facing South, c2 at (0,1) facing South.
+        // c1.OutPort → c2.InPort (auto-connected via adjacent grid cell).
+        var engine = new SimulationEngine(10, 10, 1);
+        engine.ProcessCommand(new PlaceOneWayConveyorCommand(new GridCoord(0, 0), Direction.South, 2f));
+        engine.ProcessCommand(new PlaceOneWayConveyorCommand(new GridCoord(0, 1), Direction.South, 2f));
+        var c1 = engine.State.Components[0];
+
+        // Spawn entity directly on c1 (progress = 0 → 1 needs 0.5 s at speed 2)
+        var entity = engine.State.Entities.Spawn("X", 1f, 1f, 0f, c1, c1.Ports[0].Id);
+        c1.TryAccept(entity, c1.Ports[0].Id);
+        engine.GetStateDelta(); // baseline
+
+        engine.Tick(1f);  // progress reaches 1.0 (speed=2 → 0.5s needed, 1s is enough)
+        engine.Tick(0f);  // trigger transfer (Progress >= 1.0 → attempt hand-off)
+
+        var delta = engine.GetStateDelta();
+        Assert.Contains(delta.Events,
+            e => e.Type == SimulationEventType.EntityTransferred && e.EntityId == entity.Id);
+    }
+
+    [Fact]
+    public void GetStateDelta_WhenEntityBlocked_ContainsConveyorJammedEvent()
+    {
+        // Single conveyor with no downstream — entity jams at Progress >= 1.0
+        var engine = new SimulationEngine(10, 10, 1);
+        engine.ProcessCommand(new PlaceOneWayConveyorCommand(new GridCoord(0, 0), Direction.North, 2f));
+        var c1 = engine.State.Components[0];
+
+        var entity = engine.State.Entities.Spawn("X", 1f, 1f, 0f, c1, c1.Ports[0].Id);
+        c1.TryAccept(entity, c1.Ports[0].Id);
+        engine.GetStateDelta();
+
+        engine.Tick(1f);  // progress reaches 1.0 (speed=2)
+        engine.Tick(0f);  // Progress >= 1.0 → attempts transfer, no next → jammed
+
+        var delta = engine.GetStateDelta();
+        Assert.Contains(delta.Events,
+            e => e.Type == SimulationEventType.ConveyorJammed && e.EntityId == entity.Id);
+    }
 }

--- a/Sources/Stockflow.Tests.Simulation/SimulationEngineTests.cs
+++ b/Sources/Stockflow.Tests.Simulation/SimulationEngineTests.cs
@@ -148,4 +148,36 @@ public class SimulationEngineTests
         // Facing=East: outPort at (6,5)
         Assert.Equal(new GridCoord(6, 5), merge.Ports[2].Position);
     }
+
+    [Fact]
+    public void SimulationClock_IsLiveMode_FalseByDefault()
+    {
+        var clock = new SimulationClock();
+        Assert.False(clock.IsLiveMode);
+    }
+
+    [Fact]
+    public void SimulationClock_EnterLiveMode_SetsTrue()
+    {
+        var clock = new SimulationClock();
+        clock.EnterLiveMode();
+        Assert.True(clock.IsLiveMode);
+    }
+
+    [Fact]
+    public void SimulationClock_ExitLiveMode_SetsFalse()
+    {
+        var clock = new SimulationClock();
+        clock.EnterLiveMode();
+        clock.ExitLiveMode();
+        Assert.False(clock.IsLiveMode);
+    }
+
+    [Fact]
+    public void SimulationClock_IsLiveMode_FalseAtTimeScaleOne()
+    {
+        var clock = new SimulationClock();
+        clock.TimeScale = 1f;
+        Assert.False(clock.IsLiveMode);
+    }
 }

--- a/Sources/Stockflow.Tests.Simulation/SimulationEngineTests.cs
+++ b/Sources/Stockflow.Tests.Simulation/SimulationEngineTests.cs
@@ -3,6 +3,7 @@ using Stockflow.Simulation.Component;
 using Stockflow.Simulation.Core;
 using Stockflow.Simulation.Entity;
 using Stockflow.Simulation.Grid;
+using Stockflow.Simulation.Modules;
 using Stockflow.Simulation.Routing;
 using Stockflow.Tests.Simulation.Helpers;
 
@@ -179,5 +180,29 @@ public class SimulationEngineTests
         var clock = new SimulationClock();
         clock.TimeScale = 1f;
         Assert.False(clock.IsLiveMode);
+    }
+
+    private sealed class OnTickSpyModule : IComponentModule
+    {
+        public int OnTickCallCount { get; private set; }
+        public void OnEntityEnter(SimEntity e) { }
+        public void OnEntityExit(SimEntity e)  { }
+        public void OnTick(float dt)           => OnTickCallCount++;
+    }
+
+    [Fact]
+    public void Tick_InvokesOnTickOnAllModules()
+    {
+        var engine = new SimulationEngine(10, 10, 1);
+        var spy    = new OnTickSpyModule();
+        var graph  = new RoutingGraph();
+        var conv   = new OneWayConveyor(99, new GridCoord(3, 3), Direction.North, 1f, graph,
+                                        modules: [spy]);
+        engine.State.Components.Add(conv);
+
+        engine.Tick(0.1f);
+        engine.Tick(0.1f);
+
+        Assert.Equal(2, spy.OnTickCallCount);
     }
 }

--- a/Sources/Stockflow.Webserver/Controllers/SimulationController.cs
+++ b/Sources/Stockflow.Webserver/Controllers/SimulationController.cs
@@ -44,7 +44,7 @@ public sealed class SimulationController(
             timeScale      = engine.TimeScale,
             gridWidth      = engine.Grid.Width,
             gridLength     = engine.Grid.Length,
-            gridFloors     = engine.Grid.Height,
+            gridFloors     = engine.Grid.Floors,
             components     = components.Select(c => new
             {
                 id         = c.Id,


### PR DESCRIPTION
## Summary

Corregge tutti i 13 problemi documentati in \`Docs/ISSUES_ANALYSIS_2026-05-20.md\`.

### Critical (C1–C5)
- **C1** — \`PackageGenerator\` / \`PackageExit\` ora usano l'orologio condiviso del motore (\`Func<float> getSimTime\`) per il calcolo del fulfillment time — elimina i valori negativi quando il componente è piazzato dopo che la simulazione è avviata
- **C2** — \`PackageExit.TryAccept\` ora notifica \`IComponentModule.OnEntityEnter\` su tutti i moduli
- **C3** — \`SimulationEngine.Tick\` ora invoca \`IComponentModule.OnTick(deltaTime)\` per ogni modulo di ogni componente
- **C4** — Aggiunto \`ISimComponent.PendingEvents\`; tutti i conveyor emettono \`EntityTransferred\` / \`ConveyorJammed\`; l'engine raccoglie gli eventi e li restituisce via \`StateDelta.Events\`
- **C5** — \`SimulationClock.IsLiveMode\` è ora un flag esplicito con \`EnterLiveMode()\` / \`ExitLiveMode()\`, non derivato da \`TimeScale == 1f\`

### Medium (M1–M5)
- **M1** — Progress dell'entità bloccata ora clamped a 1.0f in \`OneWayConveyor\`, \`ConveyorTurn\`, \`MergeLogic\`, \`DiverterLogic\`
- **M2** — Aggiunto \`bool SetFacing(Direction)\` a \`ISimComponent\`; implementato su \`OneWayConveyor\`, \`ConveyorTurn\`, \`DiverterLogic\` (ricostruisce le porte); \`ConfigureComponentCommand\` dispatch generico
- **M3** — \`SimEntity.CurrentComponent\` è ora \`ISimComponent?\` (nullable), rimosso il \`null!\`; null-check nei call site \`EntityState\` e \`EntityManager\`
- **M4** — \`RoutingGraph.Connect\` lancia \`InvalidOperationException\` se la porta di uscita è già connessa
- **M5** — \`MergeLogic\` starvation threshold è ora in secondi (\`StallSeconds = 1f\`), non in tick count

### Low (L1–L3)
- **L1** — \`Docs/SIMULATION_ENGINE_v0.1.md\` aggiornato con lo stato reale di tutti i componenti F0
- **L2** — \`GridManager.Height\` rinominato in \`GridManager.Floors\` (tutti i call site aggiornati)
- **L3** — \`PackageGenerator._simTime\` non si accumula più quando \`IsEnabled == false\`

## Test Plan
- [x] 153 test xUnit — tutti verdi (baseline era 136 su \`develop\`)
- [x] \`dotnet build Stockflow.slnx\` — 0 errori, 0 warning
- [x] TDD applicato: ogni fix ha il suo test rosso → verde
- [x] Spec compliance review + code quality review per ogni task

## Note
Ogni fix è in un commit separato per facilità di bisect.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)