### PR TITLE
fix(webserver): close remaining cs/log-forging CodeQL alerts

### DIFF
--- a/Sources/Stockflow.Webserver/Controllers/SessionController.cs
+++ b/Sources/Stockflow.Webserver/Controllers/SessionController.cs
@@ -107,7 +107,7 @@ public sealed class SessionController(
                 {
                     logger.LogWarning(
                         "Scenario '{Sid}': skipped preplaced #{Index} unknown type '{Type}'",
-                        scenario.Id, i, pp.Type);
+                        LogSanitizer.Clean(scenario.Id), i, LogSanitizer.Clean(pp.Type));
                     continue;
                 }
                 preplaced.Add(cmd);

--- a/Sources/Stockflow.Webserver/Controllers/SimulationController.cs
+++ b/Sources/Stockflow.Webserver/Controllers/SimulationController.cs
@@ -5,6 +5,7 @@ using Stockflow.Simulation.Component;
 using Stockflow.Simulation.Core;
 using Stockflow.Simulation.Grid;
 using Stockflow.Webserver.Configuration;
+using Stockflow.Webserver.Logging;
 using Stockflow.Webserver.Queue;
 using Stockflow.Webserver.Serialization;
 
@@ -145,7 +146,7 @@ public sealed class SimulationController(
         {
             logger.LogWarning(
                 "POST /api/sim/components → 400 unknown kind={Kind}",
-                req.Kind);
+                LogSanitizer.Clean(req.Kind));
             return BadRequest(new { success = false, errorMessage = $"Unknown component kind: {req.Kind}" });
         }
 
@@ -153,7 +154,7 @@ public sealed class SimulationController(
 
         logger.LogInformation(
             "POST /api/sim/components → enqueued {Kind} at ({X},{Y}) facing={Facing}",
-            req.Kind, req.GridX, req.GridY, req.Facing ?? "North");
+            LogSanitizer.Clean(req.Kind), req.GridX, req.GridY, LogSanitizer.Clean(req.Facing ?? "North"));
 
         return Accepted();
     }
@@ -172,7 +173,7 @@ public sealed class SimulationController(
 
         logger.LogInformation(
             "PUT /api/sim/components/{Id} → enqueued configure [{Keys}]",
-            id, string.Join(", ", props.Keys));
+            id, LogSanitizer.Clean(string.Join(", ", props.Keys)));
 
         return Accepted();
     }


### PR DESCRIPTION
## Summary
Closes the 3 CodeQL `cs/log-forging` alerts still open on `main` that were **not** part of PR #108's review diff (they live in `SimulationController`, untouched by the previous fix).

- **`SimulationController`** — sanitize `req.Kind` (×2) and `req.Facing` with `LogSanitizer.Clean` in the `PlaceComponent` log calls, and the joined `props.Keys` in `ConfigureComponent`.
- **`SessionController`** — sanitize `scenario.Id` and `pp.Type` in the "skipped preplaced unknown type" warning (defense-in-depth; the values originate from a user-authored scenario body).

Reuses the existing `LogSanitizer` helper merged via PR #109. No engine changes.

> Note: CodeQL only runs on PRs targeting `main`, so this PR (→ `develop`) won't show a CodeQL check. The alerts close once `develop` reaches `main`.

## Test plan
- [x] `dotnet build Sources/Stockflow.Webserver/` — 0 warnings, 0 errors
- [ ] CodeQL re-scan after develop→main closes alerts 1–3

🤖 Generated with [Claude Code](https://claude.com/claude-code)