### PR TITLE
fix(webserver): make CodeQL actually recognize the path-injection + last log-forging fix

### DIFF
--- a/Sources/Stockflow.Webserver/Controllers/ScenarioController.cs
+++ b/Sources/Stockflow.Webserver/Controllers/ScenarioController.cs
@@ -84,7 +84,7 @@ public sealed class ScenarioController(
         }
         catch (ScenarioNotFoundException ex)
         {
-            logger.LogWarning("PUT /api/scenarios/{Id} → 404", id);
+            logger.LogWarning("PUT /api/scenarios/{Id} → 404", LogSanitizer.Clean(id));
             return NotFound(new { errorMessage = ex.Message });
         }
     }

--- a/Sources/Stockflow.Webserver/Scenarios/FileScenarioRepository.cs
+++ b/Sources/Stockflow.Webserver/Scenarios/FileScenarioRepository.cs
@@ -86,8 +86,13 @@ public sealed partial class FileScenarioRepository : IScenarioRepository
 
     private string PathFor(string id)
     {
+        // ValidateId already guarantees the id has no path separators, but Path.GetFileName
+        // is an explicit, analyzer-recognized barrier: it strips any directory component so a
+        // crafted id can never escape the scenarios root. The canonicalized containment check
+        // is kept as belt-and-suspenders.
+        var fileName  = Path.GetFileName($"{id}.json");
         var root      = Path.GetFullPath(_scenariosPath);
-        var candidate = Path.GetFullPath(Path.Combine(root, $"{id}.json"));
+        var candidate = Path.GetFullPath(Path.Combine(root, fileName));
 
         var rootWithSep = root.EndsWith(Path.DirectorySeparatorChar)
             ? root


### PR DESCRIPTION
## Why a third PR
The previous fixes merged into `develop`, but a re-scan of PR #108 (develop → main) showed CodeQL **still** reporting:
- **6× `cs/path-injection` (high)** in `FileScenarioRepository` — the `Path.GetFullPath` + `StartsWith` containment guard is **not** recognized by CodeQL's `cs/path-injection` query as a barrier.
- **1× `cs/log-forging` (medium)** at `ScenarioController.cs:87` — a `PUT → 404` log that wraps `id` was missed in the earlier sweep (lines 71 and 78 were done, 87 was not).

## Fix
- `FileScenarioRepository.PathFor`: derive the filename through `Path.GetFileName($"{id}.json")`. `Path.GetFileName` **is** a CodeQL-recognized path-injection sanitizer — it strips any directory component so a crafted id can never escape the scenarios root. The canonicalized `StartsWith` containment check is kept as belt-and-suspenders.
- `ScenarioController` line 87: wrap `id` with `LogSanitizer.Clean`.

Verified the other log-forging alerts (4–11, 13–15) and the SessionController one are already `fixed` on develop, so this should close the remaining 7.

## Test plan
- [x] `dotnet build Sources/Stockflow.Webserver/` — 0 warnings/errors
- [x] `dotnet test` — 153 passed
- [ ] CodeQL re-scan on PR #108 shows 0 remaining path-injection / log-forging alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)