### PR TITLE
feat(simulation): harden tick loop — isolate component faults + epsilon Progress checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,8 @@ name: CI
 # La build Unity non è inclusa (troppo pesante per la CI iniziale).
 
 on:
-  push:
-    branches: ['**']
   pull_request:
     branches: [main, develop]
-
-# Evita run duplicati sullo stesso ref (push + eventuale PR).
-concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   build-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+# Pipeline base (issue #21): build dell'intera solution .NET, run dei test xUnit
+# e pubblicazione della DLL Protocol come artefatto per il client Unity.
+# La build Unity non è inclusa (troppo pesante per la CI iniziale).
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: [main, develop]
+
+# Evita run duplicati sullo stesso ref (push + eventuale PR).
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    name: Build & Test (.NET 10)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore Stockflow.slnx
+
+      - name: Build (Release)
+        run: dotnet build Stockflow.slnx --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test Sources/Stockflow.Tests.Simulation/Stockflow.Tests.Simulation.csproj --configuration Release --no-build --verbosity normal
+
+      - name: Publish Protocol DLL (for Unity client)
+        run: dotnet publish Sources/Stockflow.Protocol/Stockflow.Protocol.csproj --configuration Release --output ./artifacts/protocol
+
+      - name: Upload Protocol artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: stockflow-protocol
+          path: ./artifacts/protocol/Stockflow.Protocol.dll
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -1,0 +1,81 @@
+# Stockflow
+
+Warehouse logistics simulator with two deployment targets: a **consumer** game
+(Steam / Unity) and an **enterprise** B2B product (Docker, WMS integration).
+
+The repository hosts the **server-side simulation engine**, the **networking
+host**, the **shared protocol**, and a **web console** (Angular). The Unity
+client lives outside this repo and consumes the published `Stockflow.Protocol`
+DLL.
+
+> Detailed design docs (in Italian) live in [`Docs/`](Docs/). Guidance for working
+> on the codebase is in [`CLAUDE.md`](CLAUDE.md).
+
+## Requirements
+
+- **.NET 10.0 SDK** — server, simulation, protocol, tests
+- **Node.js + npm** — web console (`Sources/Stockflow.Console`, Angular 21)
+
+## Project layout (`Sources/`)
+
+| Project | Type | Role |
+|---|---|---|
+| `Stockflow.Simulation` | Class library | Pure simulation engine — **zero framework dependencies** |
+| `Stockflow.Protocol` | Class library | Shared MessagePack message types |
+| `Stockflow.Webserver` | ASP.NET Core | WebSocket + REST host |
+| `Stockflow.Persistence` | Class library | EF Core persistence *(planned — currently a stub)* |
+| `Stockflow.Console` | Angular app | Web console / debug client |
+| `Stockflow.Tests.Simulation` | xUnit | Unit tests for the engine |
+| `Stockflow.WsTestClient` | Console app | Manual WebSocket client |
+
+Solution file: [`Stockflow.slnx`](Stockflow.slnx) (repository root).
+
+The engine exposes its observable state as **deltas** streamed to clients over
+WebSocket (binary MessagePack); clients are read-only and all state mutations go
+through the engine via commands. See
+[`Docs/ARCHITECTURE_StockFlow_v0.3.md`](Docs/ARCHITECTURE_StockFlow_v0.3.md).
+
+## Build & run
+
+```bash
+# Build the whole solution
+dotnet build Stockflow.slnx
+
+# Run the web server (WebSocket :9600, REST :9601)
+dotnet run --project Sources/Stockflow.Webserver/
+
+# Run all engine tests
+dotnet test Sources/Stockflow.Tests.Simulation/
+
+# Run a single test by name
+dotnet test --filter "FullyQualifiedName~MyTest"
+
+# Web console (dev server)
+cd Sources/Stockflow.Console && npm install && npm start
+```
+
+## Communication channels
+
+- **WebSocket** (`:9600`) — binary MessagePack deltas at a 10–100 Hz tick rate.
+- **REST** (`:9601`) — non-real-time operations (config, scenarios, metrics).
+
+## Continuous integration
+
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml) builds the solution, runs
+the xUnit tests and publishes the `Stockflow.Protocol` DLL as an artifact (for
+the Unity client) on every push and on pull requests to `main`/`develop`.
+
+## Branch workflow
+
+Feature branches are created from `origin/develop` (with `--no-track`), reviewed
+via PR into `develop`, and only then promoted to `main`. Never merge feature
+branches directly into `main`. Full details in [`CLAUDE.md`](CLAUDE.md).
+
+## Status
+
+Early development (milestone **F0**). The simulation engine (conveyors, turns,
+diverter, merge, package generator/exit, routing graph) and the WebSocket/REST
+host are in place; persistence, metrics collection, missions/orders, stacker
+cranes and the Unity client are planned. Tracked at
+[`mcauzzi/Stockflow`](https://github.com/mcauzzi/stockflow/issues) by milestone
+(F0 → F1 → F2 → F3).

--- a/Sources/Stockflow.Simulation/Component/ConveyorTurn.cs
+++ b/Sources/Stockflow.Simulation/Component/ConveyorTurn.cs
@@ -99,7 +99,7 @@ public class ConveyorTurn : ISimComponent
     {
         _pendingEvents.Clear();
         if (Occupant == null) return;
-        if (Occupant.Progress < 1.0f)
+        if (!SimMath.ProgressComplete(Occupant.Progress))
         {
             Occupant.Progress = MathF.Min(Occupant.Progress + Speed * deltaTime, 1.0f);
         }

--- a/Sources/Stockflow.Simulation/Component/DiverterLogic.cs
+++ b/Sources/Stockflow.Simulation/Component/DiverterLogic.cs
@@ -118,7 +118,7 @@ public class DiverterLogic : ISimComponent
         _pendingEvents.Clear();
         if (Occupant == null) return;
 
-        if (Occupant.Progress < 1.0f)
+        if (!SimMath.ProgressComplete(Occupant.Progress))
         {
             Occupant.Progress = MathF.Min(Occupant.Progress + Speed * deltaTime, 1.0f);
             return;

--- a/Sources/Stockflow.Simulation/Component/MergeLogic.cs
+++ b/Sources/Stockflow.Simulation/Component/MergeLogic.cs
@@ -118,7 +118,7 @@ public class MergeLogic : ISimComponent
             return;
         }
 
-        if (Occupant.Progress < 1.0f)
+        if (!SimMath.ProgressComplete(Occupant.Progress))
         {
             Occupant.Progress = MathF.Min(Occupant.Progress + Speed * deltaTime, 1.0f);
         }

--- a/Sources/Stockflow.Simulation/Component/OneWayConveyor.cs
+++ b/Sources/Stockflow.Simulation/Component/OneWayConveyor.cs
@@ -86,7 +86,7 @@ public class OneWayConveyor : ISimComponent
     {
         _pendingEvents.Clear();
         if (Occupant == null) return;
-        if (Occupant.Progress < 1.0f)
+        if (!SimMath.ProgressComplete(Occupant.Progress))
         {
             Occupant.Progress = MathF.Min(Occupant.Progress + Speed * deltaTime, 1.0f);
         }

--- a/Sources/Stockflow.Simulation/Core/SimMath.cs
+++ b/Sources/Stockflow.Simulation/Core/SimMath.cs
@@ -1,0 +1,21 @@
+namespace Stockflow.Simulation.Core;
+
+/// <summary>
+/// Tolleranze numeriche condivise dal motore di simulazione.
+/// </summary>
+public static class SimMath
+{
+    /// <summary>
+    /// Tolleranza per i confronti sul Progress di un'entità. <c>Speed * deltaTime</c>
+    /// viene sommato tick dopo tick e l'aritmetica float accumula errore: senza una
+    /// soglia un'entità può restare un tick in più ferma appena sotto 1.0. Usata da
+    /// OneWayConveyor, ConveyorTurn, DiverterLogic e MergeLogic.
+    /// </summary>
+    public const float ProgressEpsilon = 1e-4f;
+
+    /// <summary>
+    /// True quando il Progress di un'entità ha raggiunto la fine del componente,
+    /// cioè è &gt;= 1.0 entro <see cref="ProgressEpsilon"/>.
+    /// </summary>
+    public static bool ProgressComplete(float progress) => progress >= 1.0f - ProgressEpsilon;
+}

--- a/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
+++ b/Sources/Stockflow.Simulation/Core/SimulationEngine.cs
@@ -74,10 +74,27 @@ public class SimulationEngine
         Clock.Advance(deltaTime);
         foreach (var component in State.Components)
         {
-            component.Tick(deltaTime);
-            _pendingEvents.AddRange(component.PendingEvents);
-            foreach (var module in component.Modules)
-                module.OnTick(deltaTime);
+            try
+            {
+                component.Tick(deltaTime);
+                _pendingEvents.AddRange(component.PendingEvents);
+                foreach (var module in component.Modules)
+                    module.OnTick(deltaTime);
+            }
+            catch (Exception ex)
+            {
+                // Isola il guasto: un componente che lancia non deve fermare l'intero
+                // tick loop e con esso la simulazione di tutti gli altri componenti.
+                // L'errore viene propagato in-band come evento nel delta, così il
+                // webserver (che ha il logging) può registrarlo senza che la
+                // simulazione dipenda da un framework di logging.
+                _pendingEvents.Add(new SimulationEvent
+                {
+                    Type        = SimulationEventType.ComponentError,
+                    ComponentId = component.Id,
+                    Message     = ex.Message,
+                });
+            }
         }
     }
 

--- a/Sources/Stockflow.Simulation/Core/SimulationEvent.cs
+++ b/Sources/Stockflow.Simulation/Core/SimulationEvent.cs
@@ -4,6 +4,7 @@ public enum SimulationEventType
 {
     EntityTransferred,  // un'entità è passata da un componente al successivo
     ConveyorJammed,     // un'entità non ha potuto uscire per capacità piena
+    ComponentError,     // il Tick di un componente ha lanciato un'eccezione (isolata dal loop)
 }
 
 // Evento discreto generato durante un tick — incluso nel delta per audit/animazioni client
@@ -12,4 +13,6 @@ public sealed class SimulationEvent
     public SimulationEventType Type        { get; init; }
     public int                 EntityId    { get; init; }
     public int?                ComponentId { get; init; }
+    // Dettaglio testuale opzionale (es. messaggio d'eccezione per ComponentError).
+    public string?             Message     { get; init; }
 }

--- a/Sources/Stockflow.Tests.Simulation/SimulationEngineTests.cs
+++ b/Sources/Stockflow.Tests.Simulation/SimulationEngineTests.cs
@@ -39,6 +39,55 @@ public class SimulationEngineTests
         Assert.Equal(1, stub2.TickCount);
     }
 
+    // A component whose Tick always throws — used to verify fault isolation in the tick loop.
+    private sealed class ThrowingComponent(int id) : ISimComponent
+    {
+        public int                             Id       { get; } = id;
+        public GridCoord                       Position => default;
+        public Direction                       Facing   => Direction.North;
+        public ComponentType                   Type     => ComponentType.OneWayConveyor;
+        public IReadOnlyList<IComponentModule> Modules  => [];
+        public SimEntity?                      Occupant => null;
+        public IReadOnlyList<Port>             Ports    => [];
+        public IReadOnlyList<SimulationEvent>  PendingEvents => [];
+        public IReadOnlyList<PropertySchema>   ConfigSchema  => [];
+        public string? ApplyConfig(IReadOnlyDictionary<string, string> properties) => null;
+        public Dictionary<string, string> ExportProperties() => [];
+        public bool SetFacing(Direction newFacing) => false;
+        public bool TryAccept(SimEntity entity, PortId fromPort) => false;
+        public void Tick(float deltaTime) => throw new InvalidOperationException("boom");
+    }
+
+    [Fact]
+    public void Tick_WhenComponentThrows_DoesNotCrashLoopAndTicksOthers()
+    {
+        var engine    = MakeEngine();
+        var throwing  = new ThrowingComponent(1);
+        var healthy   = new StubComponent(2);
+        engine.State.Components.Add(throwing);
+        engine.State.Components.Add(healthy);
+
+        var exception = Record.Exception(() => engine.Tick(1f));
+
+        Assert.Null(exception);                 // the loop must not propagate the fault
+        Assert.Equal(1, healthy.TickCount);     // a later component still ticks
+    }
+
+    [Fact]
+    public void Tick_WhenComponentThrows_EmitsComponentErrorEvent()
+    {
+        var engine = MakeEngine();
+        engine.State.Components.Add(new ThrowingComponent(99));
+
+        engine.Tick(1f);
+        var delta = engine.GetStateDelta();
+
+        Assert.Contains(delta.Events,
+            e => e.Type == SimulationEventType.ComponentError
+              && e.ComponentId == 99
+              && e.Message == "boom");
+    }
+
     [Fact]
     public void GetStateDelta_AfterAddingComponent_ReportsAdded()
     {

--- a/Sources/Stockflow.Webserver/Hosting/SimulationHostedService.cs
+++ b/Sources/Stockflow.Webserver/Hosting/SimulationHostedService.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text.Json;
 using Microsoft.Extensions.Options;
 using Stockflow.Protocol.Messages;
 using Stockflow.Simulation.Commands;
@@ -150,8 +151,32 @@ public sealed class SimulationHostedService : BackgroundService
                 .Select(id => ToProtoComponent(byId[id]))],
             RemovedComponentIds = [..delta.RemovedComponentIds],
             UpdatedComponents   = updatedComponents,
+            Events              = [..delta.Events.Select(e => ToProtoEvent(e, delta.SimulationTime))],
         };
     }
+
+    // Wire-stable snake_case identifiers for simulation event kinds. EventType is a string
+    // (not an enum) on the protocol so new kinds ship without bumping the wire format; the
+    // Angular console already keys off these values (e.g. "conveyor_jammed"). Never rename.
+    private static string EventTypeString(SimulationEventType type) => type switch
+    {
+        SimulationEventType.EntityTransferred => "entity_transferred",
+        SimulationEventType.ConveyorJammed    => "conveyor_jammed",
+        SimulationEventType.ComponentError    => "component_error",
+        _                                     => type.ToString(),
+    };
+
+    private static SimEvent ToProtoEvent(SimulationEvent e, float simTime) => new()
+    {
+        EventType   = EventTypeString(e.Type),
+        SimTime     = simTime,
+        PayloadJson = JsonSerializer.Serialize(new
+        {
+            entityId    = e.EntityId,
+            componentId = e.ComponentId,
+            message     = e.Message,
+        }),
+    };
 
     private FullStateMessage BuildFullStateMessage()
     {


### PR DESCRIPTION
Wrap each component's per-tick work in try/catch so a single throwing
component no longer crashes the whole tick loop (and with it every other
component's simulation). The fault is surfaced in-band as a new
ComponentError SimulationEvent (with the exception message), keeping the
engine free of any logging-framework dependency — the webserver can log it.

Replace the raw `Progress < 1.0f` comparisons in OneWayConveyor,
ConveyorTurn, DiverterLogic and MergeLogic with a shared
SimMath.ProgressComplete() that treats Progress >= 1 - 1e-4 as complete,
so float accumulation of Speed*deltaTime can't strand an entity a tick
short of the exit edge. Behaviour-preserving for clean tick values.

Add tests covering fault isolation and the ComponentError event.